### PR TITLE
fix(docs-freshness): make the changelog rule path-aware

### DIFF
--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -406,8 +406,10 @@ defineCheck("changelog-unreleased", null, () => {
   // A feat/fix that cannot reach a user — scripts/, CI, tests — is not a
   // changelog event. The published set is package.json's `files[]` (the same
   // derivation as publishedEntryNames()), plus src/ and resources/ which compile
-  // into the published dist/ entry. Unknown (no files[], no changed-path list)
-  // stays fail-closed: require a fragment rather than silently stop firing.
+  // into the published dist/ entry, plus workspace package trees from
+  // `workspaces` (they ship as their own npm packages). Unknown (no files[],
+  // no changed-path list) stays fail-closed: require a fragment rather than
+  // silently stop firing.
   //
   // Default true so a missing merge-base does not become an unpublished escape.
   let thisChangeShips = true;

--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -406,10 +406,10 @@ defineCheck("changelog-unreleased", null, () => {
   // A feat/fix that cannot reach a user — scripts/, CI, tests — is not a
   // changelog event. The published set is package.json's `files[]` (the same
   // derivation as publishedEntryNames()), plus src/ and resources/ which compile
-  // into the published dist/ entry, plus workspace package trees from
-  // `workspaces` (they ship as their own npm packages). Unknown (no files[],
-  // no changed-path list) stays fail-closed: require a fragment rather than
-  // silently stop firing.
+  // into the published dist/ entry (mapped only when dist ships), plus
+  // packages/ and examples/ which ship independently of that entry. Unknown
+  // (no files[], no changed-path list) stays fail-closed: require a fragment
+  // rather than silently stop firing.
   //
   // Default true so a missing merge-base does not become an unpublished escape.
   let thisChangeShips = true;

--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -33,6 +33,7 @@ import {
   readFragments,
   strayUnreleasedEntries,
 } from "./changelog-fragments.mjs";
+import { changeTouchesPublished } from "./published-paths.mjs";
 
 const ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 const IN_CI = !!process.env.GITHUB_ACTIONS;
@@ -299,8 +300,10 @@ defineCheck("package-name-drift", "prose doc", () => {
 
 // ── Check 5: unreleased changelog entries exist when work has landed ────────────
 // FAILS when feat/fix commits exist since the latest v* tag but no changelog
-// fragment is staged under .changelog/unreleased/. Degrades to a skip (never a
-// false fail) when there is no tag or git history to compare against.
+// fragment is staged under .changelog/unreleased/. Path-aware (flair#1098): a
+// feat/fix that touches only unpublished paths (scripts/, tests, CI) does not
+// require a fragment. Degrades to a skip (never a false fail) when there is no
+// tag or git history to compare against.
 //
 // Entries moved out of CHANGELOG.md's [Unreleased] block and into one file per
 // change (flair#835) — concurrent PRs were conflicting on those lines every time,
@@ -399,14 +402,40 @@ defineCheck("changelog-unreleased", null, () => {
     }
   }
 
-  if (commitsSinceTag !== null && commitsSinceTag > 0 && !hasContent) {
+  // ── Path awareness (flair#1098) ──────────────────────────────────────────────
+  // A feat/fix that cannot reach a user — scripts/, CI, tests — is not a
+  // changelog event. The published set is package.json's `files[]` (the same
+  // derivation as publishedEntryNames()), plus src/ and resources/ which compile
+  // into the published dist/ entry. Unknown (no files[], no changed-path list)
+  // stays fail-closed: require a fragment rather than silently stop firing.
+  //
+  // Default true so a missing merge-base does not become an unpublished escape.
+  let thisChangeShips = true;
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : "origin/main";
+  let base = "";
+  try {
+    base = execFileSync("git", ["merge-base", "HEAD", baseRef],
+      { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    if (base) {
+      const changed = execFileSync("git", ["diff", "--name-only", `${base}..HEAD`],
+        { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+      const changedPaths = changed ? changed.split("\n") : [];
+      thisChangeShips = changeTouchesPublished(changedPaths, ROOT);
+    }
+  } catch {
+    // merge-base or diff unavailable — leave thisChangeShips true (fail-closed).
+  }
+
+  if (commitsSinceTag !== null && commitsSinceTag > 0 && !hasContent && thisChangeShips) {
     failures.push({
       file: `${FRAGMENT_DIR_REL}/`, line: 1,
       msg: `no changelog fragments staged, but ${commitsSinceTag} feat/fix commit(s) have landed since the last release tag. Add ${FRAGMENT_DIR_REL}/<category>-<slug>.md describing what changed (categories: ${CATEGORIES.join(", ")}).`,
     });
   }
 
-  // ── Per-change rule (flair#1036) ─────────────────────────────────────────────
+  // ── Per-change rule (flair#1036, path-aware in flair#1098) ───────────────────
   // The rule above asks whether the DIRECTORY is non-empty, which makes it nearly
   // inert: once any one PR contributes a fragment, every subsequent PR satisfies
   // it until the next release empties the directory again. Its only live window
@@ -421,13 +450,9 @@ defineCheck("changelog-unreleased", null, () => {
   //
   // So ask the question about THIS change instead: did the commits under review
   // add a fragment? A fragment must be ADDED (--diff-filter=A) — editing someone
-  // else's staged entry is not writing your own.
-  const baseRef = process.env.GITHUB_BASE_REF
-    ? `origin/${process.env.GITHUB_BASE_REF}`
-    : "origin/main";
+  // else's staged entry is not writing your own. And only if the change touches
+  // a published path: a scripts/-only fix is not a changelog event.
   try {
-    const base = execFileSync("git", ["merge-base", "HEAD", baseRef],
-      { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
     if (base) {
       const range = `${base}..HEAD`;
       const subjects = execFileSync("git", ["log", range, "--pretty=%s"],
@@ -440,7 +465,7 @@ defineCheck("changelog-unreleased", null, () => {
         { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
       const addedCount = added ? added.split("\n").filter((p) => !/\/README\.md$/.test(p)).length : 0;
 
-      if (changeCommits > 0 && addedCount === 0) {
+      if (thisChangeShips && changeCommits > 0 && addedCount === 0) {
         failures.push({
           file: `${FRAGMENT_DIR_REL}/`, line: 1,
           msg: `this change has ${changeCommits} feat/fix commit(s) since ${baseRef} but adds no changelog fragment. The directory being non-empty is not enough — an entry already there belongs to someone else's change. Add ${FRAGMENT_DIR_REL}/<category>-<slug>.md (categories: ${CATEGORIES.join(", ")}).`,

--- a/scripts/published-paths.d.mts
+++ b/scripts/published-paths.d.mts
@@ -1,0 +1,10 @@
+/** Typings for `published-paths.mjs` — the changelog gate's published-path helpers. */
+export function publishedEntryNames(packageRoot: string): Set<string>;
+export function hasDeclaredFiles(packageRoot: string): boolean;
+export function workspaceTopLevels(packageRoot: string): Set<string>;
+export function shippingTopLevels(packageRoot: string): Set<string>;
+export function pathTouchesPublished(relPath: string, shipping: Set<string>): boolean;
+export function changeTouchesPublished(
+  relPaths: readonly string[] | null | undefined,
+  packageRoot: string,
+): boolean;

--- a/scripts/published-paths.mjs
+++ b/scripts/published-paths.mjs
@@ -8,9 +8,10 @@
 // repo so a change to one without the other is a failure, not a comment.
 //
 // Source trees are not in `files[]`. `src/` and `resources/` compile into the
-// published `dist/` entry. A top-level-name-only check would treat them as
-// unpublished and silently stop requiring fragments on real shipping changes —
-// the failure direction flair#1098 calls the worst one.
+// published `dist/` entry. Workspace packages (`workspaces` in package.json)
+// ship as their own npm packages. A top-level-name-only check would treat both
+// as unpublished and silently stop requiring fragments on real shipping
+// changes — the failure direction flair#1098 calls the worst one.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -49,15 +50,46 @@ export function hasDeclaredFiles(packageRoot) {
   }
 }
 
-export function pathTouchesPublished(relPath, published) {
+function workspacePatterns(packageRoot) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+    if (Array.isArray(pkg.workspaces)) return pkg.workspaces;
+    if (pkg.workspaces && Array.isArray(pkg.workspaces.packages)) return pkg.workspaces.packages;
+  } catch {
+    /* no workspaces declared */
+  }
+  return [];
+}
+
+/** Top-level directory names declared as npm workspaces (`packages/*` → `packages`). */
+export function workspaceTopLevels(packageRoot) {
+  return new Set(
+    workspacePatterns(packageRoot)
+      .map((w) => String(w).replace(/^\.\//, "").split("/")[0])
+      .filter((t) => t !== "" && t !== "*" && !t.startsWith("!")),
+  );
+}
+
+/**
+ * Top-level names that count as shipping for the changelog gate: `files[]` plus
+ * npm always-includes, plus source trees that compile into `dist/`, plus
+ * workspace package roots. `publishedEntryNames()` stays the deploy-filter
+ * set — this is that set plus the mappings the changelog rule has to get right.
+ */
+export function shippingTopLevels(packageRoot) {
+  const published = publishedEntryNames(packageRoot);
+  const tops = new Set(published);
+  if (published.has("dist")) {
+    for (const root of DIST_SOURCE_ROOTS) tops.add(root);
+  }
+  for (const root of workspaceTopLevels(packageRoot)) tops.add(root);
+  return tops;
+}
+
+export function pathTouchesPublished(relPath, shipping) {
   const p = String(relPath).replaceAll("\\", "/").replace(/^\.\//, "");
   if (!p) return false;
-  const top = p.split("/")[0];
-  if (published.has(top)) return true;
-  // src/ and resources/ ship via dist/. Mapping must be present or a fix: on
-  // src/cli.ts would look unpublished and the gate would go quiet.
-  if (DIST_SOURCE_ROOTS.has(top) && published.has("dist")) return true;
-  return false;
+  return shipping.has(p.split("/")[0]);
 }
 
 /**
@@ -73,6 +105,6 @@ export function changeTouchesPublished(relPaths, packageRoot) {
   if (!hasDeclaredFiles(packageRoot)) return true;
   const paths = (relPaths ?? []).map((p) => String(p).trim()).filter((p) => p !== "");
   if (paths.length === 0) return true;
-  const published = publishedEntryNames(packageRoot);
-  return paths.some((p) => pathTouchesPublished(p, published));
+  const shipping = shippingTopLevels(packageRoot);
+  return paths.some((p) => pathTouchesPublished(p, shipping));
 }

--- a/scripts/published-paths.mjs
+++ b/scripts/published-paths.mjs
@@ -8,10 +8,12 @@
 // repo so a change to one without the other is a failure, not a comment.
 //
 // Source trees are not in `files[]`. `src/` and `resources/` compile into the
-// published `dist/` entry. Workspace packages (`workspaces` in package.json)
-// ship as their own npm packages. A top-level-name-only check would treat both
-// as unpublished and silently stop requiring fragments on real shipping
-// changes — the failure direction flair#1098 calls the worst one.
+// published `dist/` entry (mapped only when `dist` itself ships). `packages/`
+// and `examples/` ship independently of that entry — workspace packages are
+// separately published, and examples already appear in CHANGELOG.md. A
+// top-level-name-only check would treat them as unpublished and silently stop
+// requiring fragments on real shipping changes — the failure direction
+// flair#1098 calls the worst one.
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -21,11 +23,20 @@ import { join } from "node:path";
 // lock; do not edit one list without the other.
 const ALWAYS = ["package.json", "README.md", "LICENSE", "LICENCE", ".env"];
 
-// Trees that compile into a published `dist/` entry.
+// Trees that compile into a published `dist/` entry. Mapped only when `dist`
+// is in the published set — without that gate, a src/ change would look like
+// it ships even if the package no longer publishes dist/.
 //   tsconfig.json            resources/** → dist/resources/**  (rootDir: ".")
 //   tsconfig.cli.json        src/cli.ts   → dist/cli.js        (rootDir: "src")
 //   tsconfig.check.src.json  src/**       → dist/src/**        (rootDir: ".")
 const DIST_SOURCE_ROOTS = new Set(["src", "resources"]);
+
+// Trees that ship even when `dist` is absent from `files[]`. Same class of
+// mapping as src/resources, but not conditional on dist: they are not compiled
+// into the root tarball. `packages/` is the workspace of separately published
+// npm packages (flair-client, flair-mcp, …). `examples/` already appears in
+// release notes; omitting it would be the same silent-skip.
+const INDEPENDENT_SHIPPING_ROOTS = new Set(["packages", "examples"]);
 
 export function publishedEntryNames(packageRoot) {
   let declared = [];
@@ -73,8 +84,10 @@ export function workspaceTopLevels(packageRoot) {
 /**
  * Top-level names that count as shipping for the changelog gate: `files[]` plus
  * npm always-includes, plus source trees that compile into `dist/`, plus
- * workspace package roots. `publishedEntryNames()` stays the deploy-filter
- * set — this is that set plus the mappings the changelog rule has to get right.
+ * independently published trees (`packages/`, `examples/`), plus any extra
+ * workspace roots declared in package.json. `publishedEntryNames()` stays the
+ * deploy-filter set — this is that set plus the mappings the changelog rule
+ * has to get right.
  */
 export function shippingTopLevels(packageRoot) {
   const published = publishedEntryNames(packageRoot);
@@ -82,6 +95,9 @@ export function shippingTopLevels(packageRoot) {
   if (published.has("dist")) {
     for (const root of DIST_SOURCE_ROOTS) tops.add(root);
   }
+  // Not gated on dist. A files[] that omitted dist/ must not excuse a
+  // packages/flair-client fix from carrying a fragment.
+  for (const root of INDEPENDENT_SHIPPING_ROOTS) tops.add(root);
   for (const root of workspaceTopLevels(packageRoot)) tops.add(root);
   return tops;
 }

--- a/scripts/published-paths.mjs
+++ b/scripts/published-paths.mjs
@@ -1,0 +1,78 @@
+// Published-path helpers for the docs-freshness changelog rule (flair#1098).
+//
+// "Does this path ship?" is a checkable fact: package.json's `files[]`, the same
+// set `publishedEntryNames()` in src/deploy.ts already reads. Hardcoding a second
+// list here is how the two sides drift. This module derives the set the same way
+// that function does — same `files[]` parse, same npm always-includes, same
+// `.env` deploy extra — and a unit test asserts the two Sets are equal on this
+// repo so a change to one without the other is a failure, not a comment.
+//
+// Source trees are not in `files[]`. `src/` and `resources/` compile into the
+// published `dist/` entry. A top-level-name-only check would treat them as
+// unpublished and silently stop requiring fragments on real shipping changes —
+// the failure direction flair#1098 calls the worst one.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Keep lockstep with `publishedEntryNames()` in src/deploy.ts, including the
+// deploy-only `.env` extra (COMPONENT_ENV_FILENAME). The agreement test is the
+// lock; do not edit one list without the other.
+const ALWAYS = ["package.json", "README.md", "LICENSE", "LICENCE", ".env"];
+
+// Trees that compile into a published `dist/` entry.
+//   tsconfig.json            resources/** → dist/resources/**  (rootDir: ".")
+//   tsconfig.cli.json        src/cli.ts   → dist/cli.js        (rootDir: "src")
+//   tsconfig.check.src.json  src/**       → dist/src/**        (rootDir: ".")
+const DIST_SOURCE_ROOTS = new Set(["src", "resources"]);
+
+export function publishedEntryNames(packageRoot) {
+  let declared = [];
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+    if (Array.isArray(pkg.files)) declared = pkg.files;
+  } catch {
+    /* caller decides what an empty set means */
+  }
+  const names = declared
+    .map((f) => String(f).replace(/^\.\//, "").replace(/\/+$/, ""))
+    .filter((f) => f !== "" && !f.includes("*") && !f.startsWith("!"));
+  return new Set([...names, ...ALWAYS]);
+}
+
+export function hasDeclaredFiles(packageRoot) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+    return Array.isArray(pkg.files) && pkg.files.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function pathTouchesPublished(relPath, published) {
+  const p = String(relPath).replaceAll("\\", "/").replace(/^\.\//, "");
+  if (!p) return false;
+  const top = p.split("/")[0];
+  if (published.has(top)) return true;
+  // src/ and resources/ ship via dist/. Mapping must be present or a fix: on
+  // src/cli.ts would look unpublished and the gate would go quiet.
+  if (DIST_SOURCE_ROOTS.has(top) && published.has("dist")) return true;
+  return false;
+}
+
+/**
+ * Whether THIS change needs a changelog fragment.
+ *
+ * Fail-closed: if `files[]` is missing we cannot prove a path is unpublished,
+ * and if the changed-path list is empty we cannot see what the change touched.
+ * Either case keeps the existing require-a-fragment behaviour. The escape is
+ * only the narrow case the issue named — every observed path is outside the
+ * published set (after the source→dist mapping).
+ */
+export function changeTouchesPublished(relPaths, packageRoot) {
+  if (!hasDeclaredFiles(packageRoot)) return true;
+  const paths = (relPaths ?? []).map((p) => String(p).trim()).filter((p) => p !== "");
+  if (paths.length === 0) return true;
+  const published = publishedEntryNames(packageRoot);
+  return paths.some((p) => pathTouchesPublished(p, published));
+}

--- a/test/unit/docs-freshness-changelog-paths.test.ts
+++ b/test/unit/docs-freshness-changelog-paths.test.ts
@@ -21,6 +21,7 @@ import {
   changeTouchesPublished,
   pathTouchesPublished,
   publishedEntryNames,
+  shippingTopLevels,
 } from "../../scripts/published-paths.mjs";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
@@ -72,6 +73,7 @@ function makePathAwareRepo(opts: {
     name: "@tpsdev-ai/flair",
     version: "0.1.0",
     private: true,
+    workspaces: ["packages/*"],
   };
   if (opts.files !== undefined) pkg.files = opts.files;
   else {
@@ -138,27 +140,46 @@ describe("published set matches publishedEntryNames()", () => {
 
 describe("pathTouchesPublished mapping", () => {
   const published = publishedEntryNames(REPO_ROOT);
+  const shipping = shippingTopLevels(REPO_ROOT);
 
   test("src/ ships via dist even though src is not in files[]", () => {
     expect(published.has("src")).toBe(false);
     expect(published.has("dist")).toBe(true);
-    expect(pathTouchesPublished("src/cli.ts", published)).toBe(true);
+    expect(pathTouchesPublished("src/cli.ts", shipping)).toBe(true);
   });
 
   test("resources/ ships via dist even though resources is not in files[]", () => {
     expect(published.has("resources")).toBe(false);
-    expect(pathTouchesPublished("resources/memory.ts", published)).toBe(true);
+    expect(pathTouchesPublished("resources/memory.ts", shipping)).toBe(true);
   });
 
   test("docs/ ships — it is in files[]", () => {
     expect(published.has("docs")).toBe(true);
-    expect(pathTouchesPublished("docs/quickstart.md", published)).toBe(true);
+    expect(pathTouchesPublished("docs/quickstart.md", shipping)).toBe(true);
+  });
+
+  test("workspace packages ship — they are separately published", () => {
+    expect(published.has("packages")).toBe(false);
+    expect(pathTouchesPublished("packages/flair-client/src/index.ts", shipping)).toBe(true);
+  });
+
+  test("workspace trees are derived from workspaces, not a hardcoded packages/", () => {
+    const dir = track(mkdtempSync(join(tmpdir(), "flair-published-workspaces-")));
+    writeFileSync(join(dir, "package.json"), JSON.stringify({
+      name: "x",
+      version: "0.0.0",
+      files: ["dist/"],
+      workspaces: ["libs/*"],
+    }));
+    const other = shippingTopLevels(dir);
+    expect(pathTouchesPublished("libs/foo/index.ts", other)).toBe(true);
+    expect(pathTouchesPublished("packages/foo/index.ts", other)).toBe(false);
   });
 
   test("scripts/, tests, and CI do not ship", () => {
-    expect(pathTouchesPublished("scripts/release.sh", published)).toBe(false);
-    expect(pathTouchesPublished("test/unit/foo.test.ts", published)).toBe(false);
-    expect(pathTouchesPublished(".github/workflows/test.yml", published)).toBe(false);
+    expect(pathTouchesPublished("scripts/release.sh", shipping)).toBe(false);
+    expect(pathTouchesPublished("test/unit/foo.test.ts", shipping)).toBe(false);
+    expect(pathTouchesPublished(".github/workflows/test.yml", shipping)).toBe(false);
   });
 
   test("missing files[] is fail-closed — cannot prove a path is unpublished", () => {
@@ -188,6 +209,18 @@ describe("changelog-unreleased per-change rule, path-aware", () => {
       commitRel: join("src", "cli.ts"),
       commitBody: "const DEFAULT_PORT = 9927;\nexport { DEFAULT_PORT };\n// shipping change\n",
       commitMsg: "fix: shipping CLI change",
+    });
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain("changelog fragment");
+    expect(res.out).toMatch(/feat\/fix commit/);
+  });
+
+  test("a feat/fix that touches packages/ still requires a fragment", () => {
+    const dir = makePathAwareRepo({
+      commitRel: join("packages", "flair-client", "src", "index.ts"),
+      commitBody: "export const n = 1;\n",
+      commitMsg: "fix: shipping workspace package change",
     });
     const res = runGate(dir);
     expect(res.status).not.toBe(0);

--- a/test/unit/docs-freshness-changelog-paths.test.ts
+++ b/test/unit/docs-freshness-changelog-paths.test.ts
@@ -60,6 +60,8 @@ function makePathAwareRepo(opts: {
   commitBody?: string;
   commitMsg: string;
   files?: unknown;
+  /** Set false to omit `workspaces` — packages/ must still ship. */
+  workspaces?: string[] | false;
 }): string {
   const dir = track(mkdtempSync(join(tmpdir(), "flair-docs-freshness-paths-")));
   const origin = track(mkdtempSync(join(tmpdir(), "flair-docs-freshness-origin-")));
@@ -73,8 +75,10 @@ function makePathAwareRepo(opts: {
     name: "@tpsdev-ai/flair",
     version: "0.1.0",
     private: true,
-    workspaces: ["packages/*"],
   };
+  if (opts.workspaces !== false) {
+    pkg.workspaces = opts.workspaces ?? ["packages/*"];
+  }
   if (opts.files !== undefined) pkg.files = opts.files;
   else {
     pkg.files = [
@@ -158,22 +162,28 @@ describe("pathTouchesPublished mapping", () => {
     expect(pathTouchesPublished("docs/quickstart.md", shipping)).toBe(true);
   });
 
-  test("workspace packages ship — they are separately published", () => {
+  test("packages/ ships even though it is not in files[] and is not via dist", () => {
     expect(published.has("packages")).toBe(false);
     expect(pathTouchesPublished("packages/flair-client/src/index.ts", shipping)).toBe(true);
+    expect(pathTouchesPublished("packages/flair-mcp/src/index.ts", shipping)).toBe(true);
   });
 
-  test("workspace trees are derived from workspaces, not a hardcoded packages/", () => {
-    const dir = track(mkdtempSync(join(tmpdir(), "flair-published-workspaces-")));
+  test("packages/ is not conditional on dist or workspaces", () => {
+    const dir = track(mkdtempSync(join(tmpdir(), "flair-published-nodist-")));
     writeFileSync(join(dir, "package.json"), JSON.stringify({
       name: "x",
       version: "0.0.0",
-      files: ["dist/"],
-      workspaces: ["libs/*"],
+      files: ["docs/"],
     }));
-    const other = shippingTopLevels(dir);
-    expect(pathTouchesPublished("libs/foo/index.ts", other)).toBe(true);
-    expect(pathTouchesPublished("packages/foo/index.ts", other)).toBe(false);
+    const noDist = shippingTopLevels(dir);
+    expect(pathTouchesPublished("packages/flair-client/src/index.ts", noDist)).toBe(true);
+    expect(pathTouchesPublished("examples/quickstart.ts", noDist)).toBe(true);
+    // src/ still requires dist to be published
+    expect(pathTouchesPublished("src/cli.ts", noDist)).toBe(false);
+  });
+
+  test("examples/ ships — already covered in release notes", () => {
+    expect(pathTouchesPublished("examples/team-concierge/index.ts", shipping)).toBe(true);
   });
 
   test("scripts/, tests, and CI do not ship", () => {
@@ -216,11 +226,14 @@ describe("changelog-unreleased per-change rule, path-aware", () => {
     expect(res.out).toMatch(/feat\/fix commit/);
   });
 
-  test("a feat/fix that touches packages/ still requires a fragment", () => {
+  test("a fix: under packages/flair-client/ with no fragment fails the real gate", () => {
+    // No workspaces field: packages/ must still trip the gate on its own,
+    // not because package.json happened to declare workspaces.
     const dir = makePathAwareRepo({
       commitRel: join("packages", "flair-client", "src", "index.ts"),
       commitBody: "export const n = 1;\n",
-      commitMsg: "fix: shipping workspace package change",
+      commitMsg: "fix: shipping flair-client change",
+      workspaces: false,
     });
     const res = runGate(dir);
     expect(res.status).not.toBe(0);

--- a/test/unit/docs-freshness-changelog-paths.test.ts
+++ b/test/unit/docs-freshness-changelog-paths.test.ts
@@ -1,0 +1,204 @@
+// docs-freshness changelog rule is path-aware (flair#1098).
+//
+// The per-change rule used to demand a fragment from any feat/fix since the
+// merge-base, regardless of which paths the change touched. A scripts/-only
+// fix cannot reach a user — it is not a changelog event. A src/ fix ships via
+// dist/ and still must carry a fragment.
+//
+// These tests are behaviour tests: they build a throwaway repo, run the real
+// gate as a subprocess, and assert on the exit code and the message. Helper
+// tests pin the published-set derivation to publishedEntryNames() so the two
+// readers cannot drift.
+
+import { describe, expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { publishedEntryNames as deployPublishedEntryNames } from "../../src/deploy.js";
+import {
+  changeTouchesPublished,
+  pathTouchesPublished,
+  publishedEntryNames,
+} from "../../scripts/published-paths.mjs";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT_REL = join("scripts", "docs-freshness-check.mjs");
+const SCRIPT_FILES = ["docs-freshness-check.mjs", "changelog-fragments.mjs", "published-paths.mjs"];
+
+const created: string[] = [];
+function track(dir: string): string {
+  created.push(dir);
+  return dir;
+}
+
+function fakeCli(n: number): string {
+  const cmds = Array.from({ length: n }, (_, i) =>
+    `{ name: () => "cmd${i}", description: () => "does thing ${i}", commands: [] }`,
+  ).join(", ");
+  return `export const program = { commands: [${cmds}] };\n`;
+}
+
+function runGate(dir: string) {
+  const r = spawnSync(process.execPath, [join(dir, SCRIPT_REL)], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_ACTIONS: "" },
+  });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+/**
+ * A repo the changelog per-change rule can see end to end: `files[]` matching
+ * the real package shape, origin/main as the merge-base, a v-tag so the
+ * since-tag half has history, and one feat/fix commit that touches `commitRel`.
+ */
+function makePathAwareRepo(opts: {
+  commitRel: string;
+  commitBody?: string;
+  commitMsg: string;
+  files?: unknown;
+}): string {
+  const dir = track(mkdtempSync(join(tmpdir(), "flair-docs-freshness-paths-")));
+  const origin = track(mkdtempSync(join(tmpdir(), "flair-docs-freshness-origin-")));
+
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+  for (const f of SCRIPT_FILES) {
+    cpSync(join(REPO_ROOT, "scripts", f), join(dir, "scripts", f));
+  }
+
+  const pkg: Record<string, unknown> = {
+    name: "@tpsdev-ai/flair",
+    version: "0.1.0",
+    private: true,
+  };
+  if (opts.files !== undefined) pkg.files = opts.files;
+  else {
+    pkg.files = [
+      "dist/",
+      "docs/",
+      "schemas/",
+      "templates/",
+      "config.yaml",
+      "LICENSE",
+      "README.md",
+      "SECURITY.md",
+    ];
+  }
+  writeFileSync(join(dir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(join(dir, "src", "cli.ts"), "const DEFAULT_PORT = 9927;\nexport { DEFAULT_PORT };\n");
+
+  writeFileSync(join(dir, "README.md"), "# Fixture\n\nNothing stale in here.\n");
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  writeFileSync(join(dir, "docs", "quickstart.md"), "# Quickstart\n\nInstall vX.Y.Z and go.\n");
+  writeFileSync(
+    join(dir, "CHANGELOG.md"),
+    "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2020-01-01\n\n### Added\n\n- Initial.\n",
+  );
+  mkdirSync(join(dir, ".changelog", "unreleased"), { recursive: true });
+  mkdirSync(join(dir, "dist"), { recursive: true });
+  writeFileSync(join(dir, "dist", "cli.js"), fakeCli(3));
+
+  const g = (...args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: ["ignore", "pipe", "ignore"] });
+  g("init", "-q", "-b", "main");
+  g("config", "user.email", "fixture@example.invalid");
+  g("config", "user.name", "Fixture");
+  g("config", "commit.gpgsign", "false");
+  g("add", "-A");
+  g("commit", "-qm", "chore: fixture");
+  g("tag", "v0.1.0");
+
+  execFileSync("git", ["init", "--bare", "-q"], { cwd: origin });
+  g("remote", "add", "origin", origin);
+  g("push", "-q", "origin", "HEAD:refs/heads/main");
+  g("fetch", "-q", "origin");
+
+  const abs = join(dir, opts.commitRel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, opts.commitBody ?? "// change\n");
+  g("add", "--", opts.commitRel);
+  g("commit", "-qm", opts.commitMsg);
+
+  return dir;
+}
+
+describe("published set matches publishedEntryNames()", () => {
+  test("the gate and the deploy filter read the same names on this repo", () => {
+    // One definition of "ships". If someone edits the always-includes in
+    // src/deploy.ts and not here (or the reverse), this is the failure.
+    const fromDeploy = [...deployPublishedEntryNames(REPO_ROOT)].sort();
+    const fromGate = [...publishedEntryNames(REPO_ROOT)].sort();
+    expect(fromGate).toEqual(fromDeploy);
+  });
+});
+
+describe("pathTouchesPublished mapping", () => {
+  const published = publishedEntryNames(REPO_ROOT);
+
+  test("src/ ships via dist even though src is not in files[]", () => {
+    expect(published.has("src")).toBe(false);
+    expect(published.has("dist")).toBe(true);
+    expect(pathTouchesPublished("src/cli.ts", published)).toBe(true);
+  });
+
+  test("resources/ ships via dist even though resources is not in files[]", () => {
+    expect(published.has("resources")).toBe(false);
+    expect(pathTouchesPublished("resources/memory.ts", published)).toBe(true);
+  });
+
+  test("docs/ ships — it is in files[]", () => {
+    expect(published.has("docs")).toBe(true);
+    expect(pathTouchesPublished("docs/quickstart.md", published)).toBe(true);
+  });
+
+  test("scripts/, tests, and CI do not ship", () => {
+    expect(pathTouchesPublished("scripts/release.sh", published)).toBe(false);
+    expect(pathTouchesPublished("test/unit/foo.test.ts", published)).toBe(false);
+    expect(pathTouchesPublished(".github/workflows/test.yml", published)).toBe(false);
+  });
+
+  test("missing files[] is fail-closed — cannot prove a path is unpublished", () => {
+    const empty = track(mkdtempSync(join(tmpdir(), "flair-published-nofiles-")));
+    writeFileSync(join(empty, "package.json"), JSON.stringify({ name: "x", version: "0.0.0" }));
+    expect(changeTouchesPublished(["scripts/only.mjs"], empty)).toBe(true);
+  });
+
+  test("an empty changed-path list is fail-closed", () => {
+    expect(changeTouchesPublished([], REPO_ROOT)).toBe(true);
+  });
+});
+
+describe("changelog-unreleased per-change rule, path-aware", () => {
+  test("a feat/fix that only touches scripts/ does not require a fragment", () => {
+    const dir = makePathAwareRepo({
+      commitRel: join("scripts", "unrelated.mjs"),
+      commitMsg: "fix: tweak a release helper",
+    });
+    const res = runGate(dir);
+    expect(res.out).not.toContain("changelog fragment");
+    expect(res.status).toBe(0);
+  });
+
+  test("a feat/fix that touches src/ still requires a fragment", () => {
+    const dir = makePathAwareRepo({
+      commitRel: join("src", "cli.ts"),
+      commitBody: "const DEFAULT_PORT = 9927;\nexport { DEFAULT_PORT };\n// shipping change\n",
+      commitMsg: "fix: shipping CLI change",
+    });
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain("changelog fragment");
+    expect(res.out).toMatch(/feat\/fix commit/);
+  });
+});
+
+describe("cleanup", () => {
+  test("removes fixtures", () => {
+    for (const d of created) rmSync(d, { recursive: true, force: true });
+    expect(true).toBe(true);
+  });
+});

--- a/test/unit/docs-freshness-skips.test.ts
+++ b/test/unit/docs-freshness-skips.test.ts
@@ -36,7 +36,7 @@ function makeFixture(opts: {
   const dir = mkdtempSync(join(tmpdir(), "flair-docs-freshness-"));
 
   mkdirSync(join(dir, "scripts"), { recursive: true });
-  for (const f of ["docs-freshness-check.mjs", "changelog-fragments.mjs"]) {
+  for (const f of ["docs-freshness-check.mjs", "changelog-fragments.mjs", "published-paths.mjs"]) {
     cpSync(join(REPO_ROOT, "scripts", f), join(dir, "scripts", f));
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1098.

The docs-freshness per-change rule demanded a changelog fragment from any `feat`/`fix` since the merge-base, without looking at which paths the change touched. A `scripts/`-only fix then had to carry a fragment nobody installs, or be retyped to `chore` so the gate would look away.

This PR makes the rule path-aware: if every file the change touches is outside the published set, no fragment is required, regardless of commit type.

## What "ships" means

The published set is `package.json`'s `files[]`, derived the same way as `publishedEntryNames()` in `src/deploy.ts` (one definition of ships — a unit test asserts the two Sets are equal on this repo). Mapped on top of that:

- `src/` and `resources/` compile into the published `dist/` entry (mapped only when `dist` itself ships)
- `packages/` and `examples/` ship independently of that entry — workspace packages are separately published, and examples already appear in CHANGELOG.md. Not conditional on `dist` or `workspaces`.

A naive top-level-name check would treat those as unpublished and silently stop firing on real changes.

Fail-closed when the published set cannot be determined (`files[]` missing) or when the changed-path list is empty.

`docs/` stays in `files[]`, so a docs-only change still needs an entry.

## Tests

`test/unit/docs-freshness-changelog-paths.test.ts`:

- A `fix:` that only touches `scripts/` does **not** trip the rule.
- A `fix:` that touches `src/` still **does**.
- A `fix:` under `packages/flair-client/` with no fragment fails the real gate (no `workspaces` field in the fixture).
- Mapping pins: `packages/` ships without `dist` and without `workspaces`; `examples/` ships; `src/` still requires `dist`; tests/CI do not.
- Gate reader and `publishedEntryNames()` agree on this repo.

No changelog fragment: CI-only, no user-facing behavior.

Does not mix #1083 or #1248. Does not touch `.cursor/install.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a215a26f-6242-46cb-bea7-3eb97a02f03f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a215a26f-6242-46cb-bea7-3eb97a02f03f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

