### PR TITLE
fix(release): mark --publish as the break-glass path

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,16 +11,22 @@ set -euo pipefail
 #         fragments into a `## [0.5.0]` CHANGELOG section, bumps + builds +
 #         tests, commits, pushes, opens PR. Review and merge via GitHub.
 #
-#   Phase 2 — publish after merge:
+#   Phase 2 — tag after merge (normal path; see docs/releasing.md):
+#     git tag v0.5.0 && git push origin v0.5.0
+#       → CI stages every package via OIDC. No npm credential on any machine.
+#
+#   Break-glass only (CI staging unavailable):
 #     ./scripts/release.sh 0.5.0 --publish
-#       → verifies main HEAD matches v0.5.0, publishes all packages
-#         to npm in dep order, tags, pushes the tag.
+#       → publishes from THIS machine. Requires an explicit acknowledgement
+#         (type BREAK-GLASS, or pass --break-glass). Who can publish is
+#         unchanged; this only marks the path.
 #
 #   ./scripts/release.sh 0.5.0 --dry
 #       → phase-1 bump + build + test on a local branch, skip push/PR.
 
-VERSION="${1:?Usage: release.sh <version> [--publish|--dry]}"
+VERSION="${1:?Usage: release.sh <version> [--publish [--break-glass]|--dry]}"
 MODE="${2:-}"
+ACK="${3:-}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # VERSION is interpolated into node -e heredocs and git/gh commands below.
@@ -83,10 +89,51 @@ git_push_auth() {
 }
 
 # -----------------------------------------------------------------------------
-# Phase 2: publish after release PR is merged
+# Break-glass: publish from this machine (CI staging unavailable)
 # -----------------------------------------------------------------------------
 if [[ "$MODE" == "--publish" ]]; then
-  echo "=== Flair Release v${VERSION} — PUBLISH ==="
+  # flair#1038: --publish is break-glass. The script used to print
+  # "🚀 Publishing to npm..." and start publishing — indistinguishable from
+  # the old laptop-login flow. Banner + acknowledgement first, before any
+  # git/npm work, so a half-remembered procedure cannot reach publish.
+  echo ""
+  echo "⚠️  --publish is the BREAK-GLASS path. The normal release is:"
+  echo "      git tag v${VERSION} && git push origin v${VERSION}"
+  echo "    which stages every package via OIDC (no npm credential on any machine)."
+  echo "    See docs/releasing.md. Continue only if CI staging is unavailable."
+  echo ""
+
+  if [[ "$ACK" == "--break-glass" ]]; then
+    echo "Acknowledged via --break-glass."
+  else
+    echo "Type BREAK-GLASS to continue, or anything else to abort:"
+    if ! read -r REPLY; then
+      echo "❌ --publish requires an explicit acknowledgement."
+      echo "   Re-run with --publish --break-glass if CI staging is unavailable."
+      echo "   The normal release is: git tag v${VERSION} && git push origin v${VERSION}"
+      exit 1
+    fi
+    if [[ "$REPLY" != "BREAK-GLASS" ]]; then
+      echo "Aborted. Nothing was published."
+      exit 1
+    fi
+  fi
+
+  # Fail with our own message before npm's ENEEDAUTH names `npm login` as
+  # the fix. Logging in would put a long-lived credential back on a machine
+  # — the thing OIDC trusted publishing was adopted to eliminate.
+  if ! npm whoami --registry https://registry.npmjs.org/ >/dev/null 2>&1; then
+    echo "❌ This machine is not logged into npm."
+    echo "   --publish publishes from THIS machine and is break-glass only."
+    echo "   The normal release does not need npm credentials:"
+    echo "     git tag v${VERSION} && git push origin v${VERSION}"
+    echo "   That stages via OIDC. See docs/releasing.md."
+    echo "   Do not run \`npm login\` unless CI staging is actually unavailable"
+    echo "   and you are deliberately using this break-glass path."
+    exit 1
+  fi
+
+  echo "=== Flair Release v${VERSION} — BREAK-GLASS PUBLISH ==="
 
   if [[ -n "$(git -C "$ROOT" status --porcelain)" ]]; then
     echo "❌ Working tree is dirty. Check out main at the release commit."
@@ -438,11 +485,17 @@ PR_TITLE="release: v${VERSION}" PR_HEAD="$RELEASE_BRANCH" PR_VERSION="$VERSION" 
 
 See CHANGELOG.md for what'"'"'s in this release.
 
-After CI is green and this is merged:
+After CI is green and this is merged, tag the release (OIDC staging — no npm login):
 \`\`\`
 git checkout main && git pull
+git tag -a v${process.env.PR_VERSION} -m "v${process.env.PR_VERSION}" && git push origin v${process.env.PR_VERSION}
+\`\`\`
+
+Break-glass only, if CI staging is unavailable:
+\`\`\`
 ./scripts/release.sh ${process.env.PR_VERSION} --publish
-\`\`\``;
+\`\`\`
+See docs/releasing.md.`;
   process.stdout.write(JSON.stringify({
     title: process.env.PR_TITLE,
     head: process.env.PR_HEAD,
@@ -459,4 +512,10 @@ echo "Next steps:"
 echo "  1. Wait for CI green on the PR"
 echo "  2. Merge via GitHub UI (or: $GH pr merge --squash --repo tpsdev-ai/flair <num>)"
 echo "  3. git checkout main && git pull"
-echo "  4. ./scripts/release.sh ${VERSION} --publish"
+echo "  4. git tag -a v${VERSION} -m \"v${VERSION}\" && git push origin v${VERSION}"
+echo "     → triggers release-publish.yml, which stage-publishes via OIDC."
+echo "       Approve the staged packages on npmjs.com (2FA)."
+echo ""
+echo "  Break-glass only, if CI staging is unavailable:"
+echo "    ./scripts/release.sh ${VERSION} --publish"
+echo "  This publishes from THIS machine and requires an npm login. See docs/releasing.md."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,16 +17,45 @@ set -euo pipefail
 #
 #   Break-glass only (CI staging unavailable):
 #     ./scripts/release.sh 0.5.0 --publish
+#     ./scripts/release.sh 0.5.0 --publish --break-glass
 #       → publishes from THIS machine. Requires an explicit acknowledgement
-#         (type BREAK-GLASS, or pass --break-glass). Who can publish is
-#         unchanged; this only marks the path.
+#         (type BREAK-GLASS, or pass --break-glass with --publish). Who can
+#         publish is unchanged; this only marks the path. --break-glass is
+#         not a mode — alone it fails closed instead of entering Phase 1.
 #
 #   ./scripts/release.sh 0.5.0 --dry
 #       → phase-1 bump + build + test on a local branch, skip push/PR.
 
 VERSION="${1:?Usage: release.sh <version> [--publish [--break-glass]|--dry]}"
-MODE="${2:-}"
-ACK="${3:-}"
+shift
+MODE=""
+ACK=""
+for arg in "$@"; do
+  case "$arg" in
+    --publish|--dry)
+      if [[ -n "$MODE" && "$MODE" != "$arg" ]]; then
+        echo "❌ Conflicting flags: $MODE and $arg"
+        echo "   Usage: release.sh <version> [--publish [--break-glass]|--dry]"
+        exit 1
+      fi
+      MODE="$arg"
+      ;;
+    --break-glass)
+      ACK="--break-glass"
+      ;;
+    *)
+      echo "❌ Unknown argument: $arg"
+      echo "   Usage: release.sh <version> [--publish [--break-glass]|--dry]"
+      exit 1
+      ;;
+  esac
+done
+if [[ "$ACK" == "--break-glass" && "$MODE" != "--publish" ]]; then
+  echo "❌ --break-glass is an acknowledgement for --publish, not a mode."
+  echo "   Use: ./scripts/release.sh ${VERSION} --publish --break-glass"
+  echo "   The normal release is: git tag v${VERSION} && git push origin v${VERSION}"
+  exit 1
+fi
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 # VERSION is interpolated into node -e heredocs and git/gh commands below.

--- a/test/unit/release-sh-break-glass.test.ts
+++ b/test/unit/release-sh-break-glass.test.ts
@@ -8,19 +8,34 @@
 
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const SCRIPT = join(REPO_ROOT, "scripts", "release.sh");
 const SRC = readFileSync(SCRIPT, "utf8");
 
-function runPublish(args: string[], stdin?: string) {
+function runPublish(args: string[], stdin?: string, env: NodeJS.ProcessEnv = process.env) {
   return spawnSync("bash", [SCRIPT, ...args], {
     encoding: "utf8",
     input: stdin,
     timeout: 20_000,
     cwd: REPO_ROOT,
+    env,
+  });
+}
+
+/** Spawn with no npm credentials so the auth gate is what actually runs. */
+function runPublishUnauth(args: string[]) {
+  const home = mkdtempSync(join(tmpdir(), "flair-release-unauth-"));
+  return runPublish(args, undefined, {
+    ...process.env,
+    HOME: home,
+    NPM_CONFIG_USERCONFIG: join(home, ".npmrc"),
+    npm_config_userconfig: join(home, ".npmrc"),
+    NPM_TOKEN: "",
+    NODE_AUTH_TOKEN: "",
   });
 }
 
@@ -69,15 +84,34 @@ describe("release.sh --publish is the break-glass path", () => {
   });
 
   test("unauthenticated --break-glass names the tag path, not npm login as the fix", () => {
-    const r = runPublish(["9.9.9", "--publish", "--break-glass"]);
+    const r = runPublishUnauth(["9.9.9", "--publish", "--break-glass"]);
     const out = output(r);
-    // This machine is not an npm publisher. The script must fail with our
-    // message so the operator is not sent to `npm login`.
-    if (out.includes("This machine is not logged into npm")) {
-      expect(out).toContain("git tag v9.9.9 && git push origin v9.9.9");
-      expect(out).toMatch(/Do not run `npm login` unless CI staging is actually unavailable/);
-    }
-    expect(r.status).not.toBe(0);
+    expect(r.status).toBe(1);
+    expect(out).toContain("This machine is not logged into npm");
+    expect(out).toContain("git tag v9.9.9 && git push origin v9.9.9");
+    expect(out).toMatch(/Do not run `npm login` unless CI staging is actually unavailable/);
+    expect(out).not.toContain("Publishing to npm");
+    expect(out).not.toMatch(/need auth You need to authorize this machine using `npm login`/);
+  });
+
+  test("--break-glass without --publish fails closed instead of entering Phase 1", () => {
+    const r = runPublish(["9.9.9", "--break-glass"]);
+    const out = output(r);
+    expect(r.status).toBe(1);
+    expect(out).toContain("--break-glass is an acknowledgement for --publish");
+    expect(out).not.toContain("PR PREP");
+    expect(out).not.toContain("Publishing to npm");
+  });
+
+  test("--break-glass --publish is accepted as publish + acknowledgement", () => {
+    const r = runPublishUnauth(["9.9.9", "--break-glass", "--publish"]);
+    const out = output(r);
+    expect(out).toContain("BREAK-GLASS");
+    expect(out).toContain("Acknowledged via --break-glass.");
+    expect(out).toContain("This machine is not logged into npm");
+    expect(r.status).toBe(1);
+    expect(out).not.toContain("PR PREP");
+    expect(out).not.toContain("Publishing to npm");
   });
 });
 

--- a/test/unit/release-sh-break-glass.test.ts
+++ b/test/unit/release-sh-break-glass.test.ts
@@ -1,0 +1,99 @@
+// flair#1038 — release.sh --publish must be unmistakably break-glass.
+//
+// Source-inspection of the same script already lives in
+// ci-gate-coverage.test.ts (partial-publish tagging). These cases spawn the
+// real script: a half-remembered `--publish` must print the banner and stop
+// before any npm publish, and phase-1 next-steps must not recruit operators
+// into this path.
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "release.sh");
+const SRC = readFileSync(SCRIPT, "utf8");
+
+function runPublish(args: string[], stdin?: string) {
+  return spawnSync("bash", [SCRIPT, ...args], {
+    encoding: "utf8",
+    input: stdin,
+    timeout: 20_000,
+    cwd: REPO_ROOT,
+  });
+}
+
+function output(r: ReturnType<typeof spawnSync>): string {
+  return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+}
+
+describe("release.sh --publish is the break-glass path", () => {
+  test("prints the BREAK-GLASS banner before any publish work", () => {
+    const r = runPublish(["9.9.9", "--publish"], "nope\n");
+    const out = output(r);
+    expect(out).toContain("BREAK-GLASS");
+    expect(out).toContain("git tag v9.9.9 && git push origin v9.9.9");
+    expect(out).toContain("docs/releasing.md");
+    expect(out).not.toContain("Publishing to npm");
+    expect(r.status).not.toBe(0);
+  });
+
+  test("declining the prompt aborts without publishing", () => {
+    const r = runPublish(["9.9.9", "--publish"], "nope\n");
+    const out = output(r);
+    expect(r.status).toBe(1);
+    expect(out).toContain("Aborted. Nothing was published.");
+    expect(out).not.toContain("Publishing to npm");
+    expect(out).not.toContain("npm login");
+  });
+
+  test("non-interactive --publish without acknowledgement refuses", () => {
+    const r = runPublish(["9.9.9", "--publish"]);
+    const out = output(r);
+    expect(r.status).toBe(1);
+    expect(out).toContain("BREAK-GLASS");
+    expect(out).toContain("--break-glass");
+    expect(out).not.toContain("Publishing to npm");
+  });
+
+  test("--break-glass acknowledges, then fails closed before npm publish", () => {
+    const r = runPublish(["9.9.9", "--publish", "--break-glass"]);
+    const out = output(r);
+    expect(out).toContain("BREAK-GLASS");
+    expect(out).toContain("Acknowledged via --break-glass.");
+    expect(r.status).not.toBe(0);
+    expect(out).not.toContain("Publishing to npm");
+    // Either our auth message or a later safety check — never npm's ENEEDAUTH.
+    expect(out).not.toMatch(/need auth You need to authorize this machine using `npm login`/);
+  });
+
+  test("unauthenticated --break-glass names the tag path, not npm login as the fix", () => {
+    const r = runPublish(["9.9.9", "--publish", "--break-glass"]);
+    const out = output(r);
+    // This machine is not an npm publisher. The script must fail with our
+    // message so the operator is not sent to `npm login`.
+    if (out.includes("This machine is not logged into npm")) {
+      expect(out).toContain("git tag v9.9.9 && git push origin v9.9.9");
+      expect(out).toMatch(/Do not run `npm login` unless CI staging is actually unavailable/);
+    }
+    expect(r.status).not.toBe(0);
+  });
+});
+
+describe("release.sh phase-1 wording does not recruit --publish", () => {
+  test("printed next-steps name the tag push as the normal path", () => {
+    const next = SRC.split('echo "Next steps:"')[1] ?? "";
+    expect(next).toContain("git tag -a v${VERSION}");
+    expect(next).toContain("stage-publishes via OIDC");
+    expect(next).toContain("Break-glass only");
+    // The old step 4 was an unmarked `--publish`. That line must not be
+    // the sole/unqualified next step anymore.
+    expect(next).toMatch(/Break-glass only[\s\S]*--publish/);
+  });
+
+  test("the release-PR body tags first and marks --publish as break-glass", () => {
+    expect(SRC).toContain("tag the release (OIDC staging — no npm login)");
+    expect(SRC).toContain("Break-glass only, if CI staging is unavailable:");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1038.

`scripts/release.sh --publish` is the break-glass path (tag + OIDC is the normal release). The script itself printed `🚀 Publishing to npm...` and started publishing, and phase-1 next-steps listed `--publish` as step 4. An unauthenticated run then failed with npm's `npm login` advice.

## What changed

At the top of `--publish`, before any git or npm work:

- A loud **BREAK-GLASS** banner naming the normal `git tag vX.Y.Z && git push origin vX.Y.Z` path
- An explicit acknowledgement: type `BREAK-GLASS`, or pass `--publish --break-glass`
- If this machine is not logged into npm, fail with our own message (tag path; do not `npm login` unless CI is actually down)

Phase-1 stdout and the release-PR body now recommend the tag + OIDC path, with `--publish` marked break-glass only.

**Who can publish is unchanged.** This only marks the path.

## Tests

`test/unit/release-sh-break-glass.test.ts` spawns the real script: banner before publish, declined/EOF confirm aborts, `--break-glass` still fails closed before `npm publish`. Source checks pin the next-steps wording.

No other issues mixed in.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cfa51bc-504a-47ba-b8b8-3d158cc9d745?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cfa51bc-504a-47ba-b8b8-3d158cc9d745&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

