### PR TITLE
fix(bootstrap): omit a dropped soul entry from the shipped map

### DIFF
--- a/.changelog/unreleased/fixed-1371-bootstrap-soul-drop-ships.md
+++ b/.changelog/unreleased/fixed-1371-bootstrap-soul-drop-ships.md
@@ -1,0 +1,5 @@
+- **Bootstrap no longer ships a soul entry it decided to drop** (flair#1371).
+  Under a tight `maxTokens`, the soul selector could drop an entry from
+  `sections.soul`, `soulTokens`, and the context pointer while still putting
+  the full key in the structured `soul` map. A decided drop now omits that
+  key, so counted == delivered.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -532,7 +532,7 @@ export class BootstrapMemories extends Resource {
     const soulMaxTokens = Math.floor(maxTokens * 0.4); // 40% of budget for soul
     if (includeSoul) {
       let soulTokens = 0;
-      const soulEntries: { key: string; line: string; tokens: number; priority: number }[] = [];
+      const soulEntries: { key: string; value: unknown; line: string; tokens: number; priority: number }[] = [];
 
       for await (const record of (databases as any).flair.Soul.search()) {
         if (record.agentId !== agentId) continue;
@@ -540,18 +540,20 @@ export class BootstrapMemories extends Resource {
           skillAssignments.push(record);
           continue;
         }
-        // flair#1182 — the raw soul container (key→value), independent of the
-        // token-budgeted/priority-truncated `sections.soul` lines built below.
-        soulMap[record.key] = record.value;
         const line = `**${record.key}:** ${record.value}`;
         const tokens = estimateTokens(line);
         const priority = SOUL_KEY_PRIORITY[record.key] ?? 50;
-        soulEntries.push({ key: record.key, line, tokens, priority });
+        soulEntries.push({ key: record.key, value: record.value, line, tokens, priority });
       }
 
       // Sort by priority (lower = more important)
       soulEntries.sort((a, b) => a.priority - b.priority);
 
+      // flair#1371 — the structured `soul` map follows the admission decision.
+      // Filling it during the scan (flair#1182) shipped every key even when
+      // this loop dropped the entry, so sections.soul / soulTokens / the
+      // context pointer described N while `soul` delivered N+1 (delivered
+      // but not counted or charged — the #1206 mirror).
       for (const entry of soulEntries) {
         if (soulTokens + entry.tokens > soulMaxTokens) {
           // Skip large entries that exceed budget — truncate or skip
@@ -561,6 +563,7 @@ export class BootstrapMemories extends Resource {
           if (maxChars > 100) {
             const truncated = `**${entry.key}:** ${entry.line.slice(entry.key.length + 6, entry.key.length + 6 + maxChars)}…(truncated)`;
             sections.soul.push(truncated);
+            soulMap[entry.key] = entry.value;
             const cost = estimateTokens(truncated);
             soulTokens += cost;
             tokenBudget -= cost; // #1199 — soul draws from the shared budget
@@ -568,6 +571,7 @@ export class BootstrapMemories extends Resource {
           continue;
         }
         sections.soul.push(entry.line);
+        soulMap[entry.key] = entry.value;
         soulTokens += entry.tokens;
         tokenBudget -= entry.tokens; // #1199 — soul draws from the shared budget
       }

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -611,9 +611,10 @@ export interface ToolInvariants {
   /**
    * A self-describing COUNT field must equal the TOTAL length of the
    * container(s) it describes: counted == delivered (flair#1199
-   * memoriesIncluded/teammateFindingsIncluded; flair#1206 sections.events).
-   * `count` may be a dotted path (e.g. "sections.events"); `containers` are
-   * top-level arrays whose lengths SUM to the count.
+   * memoriesIncluded/teammateFindingsIncluded; flair#1206 sections.events;
+   * flair#1371 sections.soul). `count` may be a dotted path (e.g.
+   * "sections.events"); `containers` are top-level arrays (`.length`) or
+   * object maps (`Object.keys().length`) whose sizes SUM to the count.
    *
    * `containers` is a list, not a single name, because `memoriesIncluded`
    * legitimately spans TWO delivered own-memory containers: `memories`
@@ -1152,6 +1153,7 @@ export const TOOLS: Record<string, ToolEntry> = {
           { count: "memoriesIncluded", containers: ["memories", "predicted"] },     // #1199
           { count: "teammateFindingsIncluded", containers: ["teammateFindings"] },  // #1199
           { count: "sections.events", containers: ["events"] },                     // #1206
+          { count: "sections.soul", containers: ["soul"] },                         // #1371
         ],
         // present + typed even when empty — never a bare {} / missing key (#1182).
         selfDescribingEmpty: [

--- a/test/helpers/mcp-conformance.ts
+++ b/test/helpers/mcp-conformance.ts
@@ -104,12 +104,22 @@ export function conform(toolName: string, result: any, contract: ToolContract, o
   for (const { count, containers } of inv.countEqualsDelivered ?? []) {
     let total = 0;
     for (const c of containers) {
-      const arr = getPath(result, c);
-      expect(Array.isArray(arr), `${toolName}: container '${c}' must be an array for count==delivered`).toBe(true);
-      total += arr.length;
+      const val = getPath(result, c);
+      if (Array.isArray(val)) {
+        total += val.length;
+      } else if (val !== null && typeof val === "object") {
+        // flair#1371 — soul is a key→value map, not an array. Counted ==
+        // delivered is |keys|, the same number sections.soul reports.
+        total += Object.keys(val).length;
+      } else {
+        expect(
+          false,
+          `${toolName}: container '${c}' must be an array or object map for count==delivered (got ${jsTypeOf(val)})`,
+        ).toBe(true);
+      }
     }
     const reported = getPath(result, count);
-    expect(reported, `${toolName}: ${count} (=${reported}) must equal Σ[${containers.join(", ")}] lengths (=${total})`).toBe(total);
+    expect(reported, `${toolName}: ${count} (=${reported}) must equal Σ[${containers.join(", ")}] sizes (=${total})`).toBe(total);
   }
 
   for (const { path, type } of inv.selfDescribingEmpty ?? []) {

--- a/test/unit-isolated/memory-bootstrap-scoping.test.ts
+++ b/test/unit-isolated/memory-bootstrap-scoping.test.ts
@@ -68,6 +68,7 @@ function matchesCondition(record: any, cond: any): boolean {
 
 let memoryStore: Map<string, any>;
 let memoryGrants: any[];
+let soulStore: Map<string, any> = new Map();
 
 function memorySearchGen(query: any) {
   const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
@@ -109,7 +110,14 @@ const databasesMock = {
         return gen();
       },
     },
-    Soul: { search: () => emptyGen() },
+    Soul: {
+      search: () => {
+        async function* gen() {
+          for (const r of soulStore.values()) yield r;
+        }
+        return gen();
+      },
+    },
     Agent: { search: () => emptyGen(), get: async () => null },
     Relationship: { search: () => emptyGen() },
     OrgEvent: { search: () => emptyGen() },
@@ -132,6 +140,7 @@ const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tps
 function reset() {
   memoryStore = new Map();
   memoryGrants = [];
+  soulStore = new Map();
   embedInputTypeCalls = [];
 }
 
@@ -590,5 +599,54 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
     // which here is empty → no header at all).
     expect(res.context).not.toContain("## Core Principles");
     expect(res.sections.permanent).toBe(0);
+  });
+});
+
+// flair#1371 — soul admission used to decide a drop (count, charge, context
+// pointer) and then ship the full key→value map anyway. The discriminating
+// check is shipped-vs-counted (`sections.soul === |soul| keys`), not the
+// #1290 token-ledger tolerance (an uncharged small item hides inside it).
+describe("MemoryBootstrap.post() — soul admission vs shipped map (flair#1371)", () => {
+  function seedSoul(agentId: string, key: string, value: string) {
+    soulStore.set(`${agentId}:${key}`, { id: `${agentId}:${key}`, agentId, key, value });
+  }
+
+  it("a decided soul drop is absent from the shipped map; sections.soul matches the keys", async () => {
+    reset();
+    const agentId = "agent-soul-1371";
+    // Four entries mirroring the live 0.48.0 case. `role` is priority 0; the
+    // rest share default priority 50 and keep insertion order after the sort.
+    seedSoul(agentId, "role", "r".repeat(40));
+    seedSoul(agentId, "security-context", "s".repeat(80));
+    seedSoul(agentId, "user", "u".repeat(80));
+    seedSoul(agentId, "flair-usage", "f".repeat(80));
+
+    const b = makeBootstrap(agentCtx(agentId));
+    const wide: any = await b.post({
+      agentId, maxTokens: 4000, includeContext: false,
+    });
+    expect(Object.keys(wide.soul).sort()).toEqual(
+      ["flair-usage", "role", "security-context", "user"],
+    );
+    expect(wide.sections.soul).toBe(4);
+    expect(Object.keys(wide.soul).length).toBe(wide.sections.soul);
+
+    // soulMaxTokens = floor(200 * 0.4) = 80. role + security-context + user
+    // fit; flair-usage does not, and remaining room is < 100 chars so the
+    // loop skips rather than truncates — a decided drop.
+    const tight: any = await b.post({
+      agentId, maxTokens: 200, includeContext: false,
+    });
+    expect(tight.sections.soul, "tight budget must drop at least one soul entry").toBeLessThan(4);
+    expect(tight.sections.soul, "sections.soul must equal shipped soul keys").toBe(Object.keys(tight.soul).length);
+    expect(
+      tight.soul["flair-usage"],
+      "the dropped flair-usage entry must not ship in the structured map",
+    ).toBeUndefined();
+    expect(tight.soul.role, "higher-priority role still ships").toBe("r".repeat(40));
+    expect(tight.context, "context pointer must describe the shipped count").toContain(
+      `${tight.sections.soul} soul entries`,
+    );
+    expect(tight.soulTokens, "dropped entry must not be charged").toBeLessThan(wide.soulTokens);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1371.

Bootstrap’s soul admission already decided a drop under a tight `maxTokens` — `sections.soul`, `soulTokens`, and the context pointer all said so — then shipped the full key→value map anyway. The dropped entry was delivered, uncounted, and uncharged (the #1206 mirror: delivered but not counted).

This keeps soul budget-elidable (the selector already treats it that way) and makes the shipped map follow that decision. A skipped entry is no longer written into `soul`. The #1290 `countEqualsDelivered` invariant now checks `sections.soul === |soul| keys`, which is the cross-check the token-ledger tolerance cannot see.

Assigned to @heskew.

## What changed

- `MemoryBootstrap` fills the structured `soul` map from the admission loop, not from the full scan.
- `countEqualsDelivered` accepts object maps so `sections.soul` can be checked against `soul`.
- Unit-isolated test: four soul entries, generous budget ships all four; tight budget drops `flair-usage` from the map and the count matches.

Changelog fragment: `.changelog/unreleased/fixed-1371-bootstrap-soul-drop-ships.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57ec1448-1f9e-4c76-aa5b-c7eb37f716d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57ec1448-1f9e-4c76-aa5b-c7eb37f716d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

