### PR TITLE
fix(mcp): expose record_usage on the stdio MCP surface

### DIFF
--- a/.changelog/unreleased/fixed-1147-record-usage-mcp.md
+++ b/.changelog/unreleased/fixed-1147-record-usage-mcp.md
@@ -1,0 +1,7 @@
+- **stdio MCP clients can record usage.** `@tpsdev-ai/flair-mcp` now exposes
+  `record_usage` (POST `/RecordUsage`: memory id + optional one-line
+  how-it-was-used) and an optional `usedMemoryIds` passthrough on
+  `memory_store` / `memory_update`. `memory_search` and `bootstrap` append a
+  one-line nudge to cite what you actually use — a search hit is not usage.
+  Native `/mcp` already had this surface; the stdio package the issue named
+  did not (flair#1147).

--- a/docs/deepseek-harness.md
+++ b/docs/deepseek-harness.md
@@ -4,7 +4,7 @@ Give DeepSeek Harness (DSH) sessions persistent, portable memory — no plugin c
 
 > **Verified against DSH as of 2026-08-20** (`deepseek-ai/deepseek-harness`, branch `master`). DSH is a developer preview and its own README promises compatibility-breaking changes. If wiring fails after a DSH upgrade, re-check the config field names against [their MCP client README](https://github.com/deepseek-ai/deepseek-harness/blob/master/packages/mcp/mcp-client/README.md) before suspecting Flair.
 
-The same eleven tools every other MCP client gets ([full table in mcp-clients.md](mcp-clients.md#what-the-mcp-server-exposes)) appear to the model under DSH's server-qualified names: `mcp__flair__memory_search`, `mcp__flair__memory_store`, `mcp__flair__bootstrap`, and so on — the same `mcp__<server>__<tool>` convention Claude Code uses.
+The same twelve tools every other MCP client gets ([full table in mcp-clients.md](mcp-clients.md#what-the-mcp-server-exposes)) appear to the model under DSH's server-qualified names: `mcp__flair__memory_search`, `mcp__flair__memory_store`, `mcp__flair__bootstrap`, and so on — the same `mcp__<server>__<tool>` convention Claude Code uses.
 
 Two caveats up front, both structural to DSH's bridge (details below):
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -273,13 +273,13 @@ If you see (a) the agent calling the `bootstrap` tool returning soul + recent me
 
 ## What the MCP server exposes
 
-Eleven tools, kept deliberately small:
+Twelve tools, kept deliberately small:
 
 | Tool | What it does |
 |---|---|
 | `memory_search` | Semantic search across your agent's memories |
-| `memory_store` | Save a memory with type, durability, tags, visibility. Auto-dedups near-duplicates |
-| `memory_update` | Update an existing memory by ID — overwrite in place, or version it with `preserveHistory` |
+| `memory_store` | Save a memory with type, durability, tags, visibility. Auto-dedups near-duplicates. Optional `usedMemoryIds` cites memories that informed the write |
+| `memory_update` | Update an existing memory by ID — overwrite in place, or version it with `preserveHistory`. Optional `usedMemoryIds` for citation-on-write |
 | `memory_get` | Fetch a specific memory by ID |
 | `memory_delete` | Remove a memory |
 | `relationship_store` | Record a subject-predicate-object relationship triple (e.g. "nathan manages flair") |
@@ -288,6 +288,7 @@ Eleven tools, kept deliberately small:
 | `soul_get` | Get a soul entry |
 | `flair_workspace_set` | Set your agent's current workspace state (ref/branch, phase, task) in the Office Space |
 | `flair_orgevent` | Publish an org-wide coordination event (claim/release/status) to the Office Space |
+| `record_usage` | Report that recalled memories were actually used (id + optional one-line how-it-was-used). Drives `usageCount` / `usageBoost` |
 
 Writes are scoped per-agent (your `FLAIR_AGENT_ID`) and enforced by Flair's server, not by client convention — you can't write as another agent. Reads are more open by design: any agent on the same Flair instance can read any other agent's **non-private** memories, with no grant to set up (open-within-org read; see [SECURITY.md](../SECURITY.md)).
 

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -204,6 +204,11 @@ class MemoryApi {
     /** Cosine-similarity threshold hint for the server's dedup gate.
      *  Default (server-side): 0.95 */
     dedupThreshold?: number;
+    /** Citation-on-write (flair#1147 / #744). IDs of memories that informed
+     *  this write. Forwarded only when the caller supplies a non-empty array;
+     *  the server credits each id through the same usage ledger as
+     *  POST /RecordUsage and strips the field before persisting. */
+    usedMemoryIds?: string[];
   } = {}): Promise<Memory> {
     const id = opts.id ?? `${this.client.agentId}-${crypto.randomUUID()}`;
     const record: Record<string, unknown> = {
@@ -225,6 +230,11 @@ class MemoryApi {
     // never stored on the record itself.
     if (opts.dedup !== undefined) record.dedup = opts.dedup;
     if (opts.dedupThreshold !== undefined) record.dedupThreshold = opts.dedupThreshold;
+    // flair#1147: citation-on-write passthrough — only when supplied, so an
+    // omitted list is byte-identical to a pre-#1147 write.
+    if (Array.isArray(opts.usedMemoryIds) && opts.usedMemoryIds.length > 0) {
+      record.usedMemoryIds = opts.usedMemoryIds;
+    }
     // flair#718 authorship-provenance: forward this process's claimed client
     // label (config.claimedClient / FLAIR_CLIENT env) only when set — the
     // server folds it into provenance.claimed.client and strips it from the
@@ -259,7 +269,7 @@ class MemoryApi {
    * MemoryGrant from that owner — otherwise it denies the request (cross-agent
    * write).
    */
-  async update(id: string, content: string, opts: { preserveHistory?: boolean } = {}): Promise<Memory> {
+  async update(id: string, content: string, opts: { preserveHistory?: boolean; usedMemoryIds?: string[] } = {}): Promise<Memory> {
     const existing = await this.get(id);
     if (!existing) {
       throw new FlairError("PUT", `/Memory/${id}`, 404, `memory ${id} not found`);
@@ -294,6 +304,9 @@ class MemoryApi {
       delete record.lastRetrieved;
       // flair#718 authorship-provenance — see write()'s identical comment above.
       if (this.client.claimedClient) record.claimedClient = this.client.claimedClient;
+      if (Array.isArray(opts.usedMemoryIds) && opts.usedMemoryIds.length > 0) {
+        record.usedMemoryIds = opts.usedMemoryIds;
+      }
       // The Memory schema does not expose a working HTTP POST route (see
       // resources/Memory.ts) — Memory.post() is only reachable in-process
       // (resources/mcp-tools.ts). So the supersede-link write goes through
@@ -314,6 +327,9 @@ class MemoryApi {
     delete merged.deduped;
     // flair#718 authorship-provenance — see write()'s identical comment above.
     if (this.client.claimedClient) merged.claimedClient = this.client.claimedClient;
+    if (Array.isArray(opts.usedMemoryIds) && opts.usedMemoryIds.length > 0) {
+      merged.usedMemoryIds = opts.usedMemoryIds;
+    }
     const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${id}`, merged);
     return { ...merged, id, ...(response ?? {}) } as unknown as Memory;
   }

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -347,6 +347,28 @@ describe("MemoryApi", () => {
     expect(body.visibility).toBe("shared");
   });
 
+  test("write() forwards usedMemoryIds ONLY when the caller supplies a non-empty list (flair#1147)", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.write("content long enough to matter", { usedMemoryIds: ["mem-cited"] });
+
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.usedMemoryIds).toEqual(["mem-cited"]);
+  });
+
+  test("write() omits usedMemoryIds entirely when the caller doesn't set it — no client-side default", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.write("content long enough to matter");
+
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect("usedMemoryIds" in body).toBe(false);
+  });
+
   test("update() default mode: reads existing, PUTs merged content to the SAME id, clears stale embedding", async () => {
     const existing = {
       id: "mem-1", agentId: "test", content: "old content", type: "session",
@@ -411,6 +433,27 @@ describe("MemoryApi", () => {
     await expect(client.memory.update("nonexistent", "x")).rejects.toThrow();
     // Only the GET happened — no PUT was attempted.
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("update() forwards usedMemoryIds on the in-place PUT (flair#1147)", async () => {
+    const existing = {
+      id: "mem-1", agentId: "test", content: "old content", type: "session",
+      durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z",
+    };
+    mockFetch = mock((_url: string, init?: any) => {
+      if (init?.method === "GET") {
+        return Promise.resolve(new Response(JSON.stringify(existing), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ written: true }), { status: 200 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.update("mem-1", "new content", { usedMemoryIds: ["mem-cited"] });
+
+    const putCall = (mockFetch as any).mock.calls.find((c: any) => c[1].method === "PUT");
+    const putBody = JSON.parse(putCall[1].body);
+    expect(putBody.usedMemoryIds).toEqual(["mem-cited"]);
   });
 
   // ─── flair#718 authorship-provenance — claimedClient forwarding on memory writes ──

--- a/packages/flair-mcp/README.md
+++ b/packages/flair-mcp/README.md
@@ -41,12 +41,13 @@ Once configured, Claude Code (or any MCP client) gets these tools:
 | Tool | Description |
 |------|-------------|
 | `memory_search` | Semantic search across memories. Understands "what happened today". |
-| `memory_store` | Save a memory with type (lesson/decision/fact) and durability. |
+| `memory_store` | Save a memory with type (lesson/decision/fact) and durability. Optional `usedMemoryIds` cites memories that informed the write. |
 | `memory_get` | Retrieve a specific memory by ID. |
 | `memory_delete` | Delete a memory. |
 | `bootstrap` | Cold-start context — soul + recent memories in one call. |
 | `soul_set` | Set personality or project context (included in every bootstrap). |
 | `soul_get` | Get a personality or project context entry. |
+| `record_usage` | Report that recalled memories were actually used (drives `usageCount`). |
 
 ## Environment Variables
 

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -15,6 +15,7 @@
  *   - soul_get       — get a personality/context entry
  *   - flair_workspace_set — write own WorkspaceState (Office Space coordination)
  *   - flair_orgevent      — publish an OrgEvent attributed to self (no forging)
+ *   - record_usage        — report that recalled memories were actually used (flair#1147)
  *
  * Auto-presence (flair#598): every tool call above triggers a fire-and-forget,
  * rate-limited `POST /Presence` heartbeat for the calling agent (see
@@ -53,6 +54,7 @@ import {
   type PresenceActivity,
 } from "./presence.js";
 import { readEnvOrUnset, stripInterpolationLiteralsFromEnv } from "./env-guard.js";
+import { buildRecordUsageBody, citationIds, withCiteNudge } from "./usage.js";
 import { serverInfo } from "./version.js";
 
 // ─── Error helpers ──────────────────────────────────────────────────────────
@@ -261,7 +263,7 @@ export async function runMcp(): Promise<void> {
           return `${i + 1}. ${r.content}${meta ? ` (${meta})` : ""}`;
         })
         .join("\n");
-      return { content: [{ type: "text", text }] };
+      return { content: [{ type: "text", text: withCiteNudge(text) }] };
     } catch (err) {
       return errorResult(err, flair.url);
     }
@@ -288,8 +290,12 @@ server.tool(
       "private -- never visible to another agent, even one with a memory grant. " +
       "shared -- visible to the owner and any agent holding a read/search grant.",
     ),
+    usedMemoryIds: z.array(z.string()).optional().describe(
+      "IDs of memories that informed this write (citation-on-write). Credited via the same " +
+      "deduped usage ledger as record_usage. Optional.",
+    ),
   },
-  async ({ content, type, durability, tags, visibility }) => {
+  async ({ content, type, durability, tags, visibility, usedMemoryIds }) => {
     heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const result = await flair.memory.write(content, {
@@ -299,6 +305,7 @@ server.tool(
         visibility: visibility as any,
         dedup: true,
         dedupThreshold: 0.95,
+        usedMemoryIds: citationIds(usedMemoryIds),
       });
       // The server's conservative dedup gate NEVER suppresses a write
       // (memory-integrity fix, flair#526) — `result.deduplicated` is a
@@ -349,11 +356,18 @@ server.tool(
     content: z.string().describe("New content"),
     preserveHistory: z.coerce.boolean().optional().default(false)
       .describe("Write a new supersedes-linked version instead of overwriting in place (default false)"),
+    usedMemoryIds: z.array(z.string()).optional().describe(
+      "IDs of memories that informed this update (citation-on-write). Credited via the same " +
+      "deduped usage ledger as record_usage. Optional.",
+    ),
   },
-  async ({ id, content, preserveHistory }) => {
+  async ({ id, content, preserveHistory, usedMemoryIds }) => {
     heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
-      const result = await flair.memory.update(id, content, { preserveHistory });
+      const result = await flair.memory.update(id, content, {
+        preserveHistory,
+        usedMemoryIds: citationIds(usedMemoryIds),
+      });
       const text = preserveHistory
         ? `Memory updated: new version stored (id: ${result.id}), supersedes ${id}.`
         : `Memory updated (id: ${id}).`;
@@ -471,7 +485,7 @@ server.tool(
       if (!result.context) {
         return { content: [{ type: "text", text: "No context available." }] };
       }
-      return { content: [{ type: "text", text: result.context }] };
+      return { content: [{ type: "text", text: withCiteNudge(result.context) }] };
     } catch (err) {
       return errorResult(err, flair.url);
     }
@@ -579,6 +593,44 @@ server.tool(
       const targetStr = targets && targets.length > 0 ? ` → ${targets.join(", ")}` : "";
       const idStr = result?.id ? ` (id: ${result.id})` : "";
       return { content: [{ type: "text", text: `OrgEvent published: kind=${kind}${targetStr} (attributed to ${agentId})${idStr}.` }] };
+    } catch (err) {
+      return errorResult(err, flair.url);
+    }
+  },
+);
+
+// ─── Usage feedback (flair#1147) ─────────────────────────────────────────────
+//
+// POST /RecordUsage already existed; native /mcp already wrapped it. The
+// stdio package did not, so a Claude Code / Cursor client could not close
+// the usageCount loop. Identity is taken from the signed request — the body
+// carries only memory id(s) + optional attribution, never agentId.
+
+server.tool(
+  "record_usage",
+  "Report that one or more memories were actually USED — cited or relied on to ground an answer or decision. " +
+    "Distinct from search (surfacing a memory is not usage). Dedup'd (you can only count once per memory) and rate-limited.",
+  {
+    memoryId: z.string().optional().describe("A single memory id that was used"),
+    memoryIds: z.array(z.string()).optional().describe("IDs of the memories that were used (max 20 per call)"),
+    attribution: z.string().optional().describe("Optional one-line note on how it was used (opaque — stored for audit only)"),
+  },
+  async ({ memoryId, memoryIds, attribution }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
+    try {
+      const body = buildRecordUsageBody({ memoryId, memoryIds, attribution });
+      if (!body) {
+        return {
+          content: [{ type: "text", text: "record_usage requires memoryId or memoryIds." }],
+          isError: true,
+        };
+      }
+      const result = await flair.request<{ recorded?: boolean }>("POST", "/RecordUsage", body);
+      const text = result?.recorded === true ? "Usage recorded." : "Usage request accepted.";
+      return {
+        content: [{ type: "text", text }],
+        structuredContent: { recorded: result?.recorded === true },
+      };
     } catch (err) {
       return errorResult(err, flair.url);
     }

--- a/packages/flair-mcp/src/usage.ts
+++ b/packages/flair-mcp/src/usage.ts
@@ -25,6 +25,20 @@ export function withCiteNudge(text: string): string {
  * Accepts singular `memoryId` and/or `memoryIds`. Returns null when there is
  * nothing to send (the tool should fail locally rather than POST an empty list).
  * Never includes agentId — the server attributes from the signature.
+ *
+ * MERGE vs native /mcp PREFER (deliberate, named — Sherlock #1404):
+ * native `recordUsage` in resources/mcp-tools.ts prefers `memoryIds` and
+ * drops `memoryId` when both are supplied (`Array.isArray(args?.memoryIds)
+ * ? args.memoryIds : [args.memoryId]`). This stdio helper MERGES them, then
+ * dedupes. A client that fills both fields (common when an agent echoes
+ * the singular convenience into a list) would silently lose the singular
+ * id on the native path; dropping a citation here would reopen the
+ * usageCount hole this issue exists to close. Server-side
+ * `RecordUsage.post()` already unions `memoryIds` / `memoryId` the same
+ * way (`data?.memoryIds ?? [data?.memoryId]` is prefer, but once we send
+ * a merged `memoryIds` array the endpoint sees one list). Do not "align"
+ * this helper to the native prefer — the merge is the intended stdio
+ * behavior; native prefer is pre-existing and out of this issue's scope.
  */
 export function buildRecordUsageBody(args: {
   memoryId?: string;

--- a/packages/flair-mcp/src/usage.ts
+++ b/packages/flair-mcp/src/usage.ts
@@ -26,19 +26,24 @@ export function withCiteNudge(text: string): string {
  * nothing to send (the tool should fail locally rather than POST an empty list).
  * Never includes agentId — the server attributes from the signature.
  *
- * MERGE vs native /mcp PREFER (deliberate, named — Sherlock #1404):
- * native `recordUsage` in resources/mcp-tools.ts prefers `memoryIds` and
- * drops `memoryId` when both are supplied (`Array.isArray(args?.memoryIds)
- * ? args.memoryIds : [args.memoryId]`). This stdio helper MERGES them, then
- * dedupes. A client that fills both fields (common when an agent echoes
- * the singular convenience into a list) would silently lose the singular
- * id on the native path; dropping a citation here would reopen the
- * usageCount hole this issue exists to close. Server-side
- * `RecordUsage.post()` already unions `memoryIds` / `memoryId` the same
- * way (`data?.memoryIds ?? [data?.memoryId]` is prefer, but once we send
- * a merged `memoryIds` array the endpoint sees one list). Do not "align"
- * this helper to the native prefer — the merge is the intended stdio
- * behavior; native prefer is pre-existing and out of this issue's scope.
+ * MERGE vs PREFER (deliberate, named — Sherlock/Kern #1404):
+ * This helper MERGES `memoryId` + `memoryIds`, then dedupes. Native `/mcp`
+ * `recordUsage` (resources/mcp-tools.ts) PREFERS `memoryIds` and drops
+ * `memoryId` when both are supplied. The HTTP endpoint does the same:
+ * `RecordUsage.post()` is `data?.memoryIds ?? [data?.memoryId]` — PREFER,
+ * not union. If `memoryIds` is present (even `[]`, which is truthy),
+ * `memoryId` is never read.
+ *
+ * The stdio merge is load-bearing because it flattens first: we send only
+ * a single `memoryIds` array, so the server's prefer is never exercised
+ * on two fields. A future path that POSTs both fields through to
+ * `/RecordUsage` without flattening would silently drop `memoryId`
+ * (delivered-but-uncounted; empty `memoryIds: []` alongside a real
+ * `memoryId` would 400 rather than fall through).
+ *
+ * Native prefer is a pre-existing delivered-but-uncounted bug on a
+ * different surface, tracked in flair#1410 — not a regression from this
+ * PR, and not a blocker for #1147. Do not "align" this helper to prefer.
  */
 export function buildRecordUsageBody(args: {
   memoryId?: string;

--- a/packages/flair-mcp/src/usage.ts
+++ b/packages/flair-mcp/src/usage.ts
@@ -1,0 +1,61 @@
+/**
+ * flair#1147 — the usage-feedback loop on the stdio MCP surface.
+ *
+ * Native `/mcp` already exposes `record_usage` and `memory_store.usedMemoryIds`.
+ * The stdio package (`@tpsdev-ai/flair-mcp`) did not, so a Claude Code / Cursor
+ * client had no way to reach POST /RecordUsage. These helpers are the thin
+ * client-side half: body construction for that endpoint, citation passthrough
+ * on write, and the one-line "cite what you use" nudge on recalled ids.
+ *
+ * Identity is NEVER in the body — RecordUsage attributes from the signed
+ * request, same no-forge contract as flair_workspace_set / flair_orgevent.
+ */
+
+/** One-line instruction on recalled ids (issue ask #3). Search/bootstrap hits are not usage. */
+export const CITE_USAGE_NUDGE =
+  "Cite memories you actually use via record_usage (or memory_store.usedMemoryIds). A search or bootstrap hit is not usage.";
+
+export function withCiteNudge(text: string): string {
+  if (!text) return text;
+  return `${text}\n\n${CITE_USAGE_NUDGE}`;
+}
+
+/**
+ * Build the POST /RecordUsage body from the MCP tool args.
+ * Accepts singular `memoryId` and/or `memoryIds`. Returns null when there is
+ * nothing to send (the tool should fail locally rather than POST an empty list).
+ * Never includes agentId — the server attributes from the signature.
+ */
+export function buildRecordUsageBody(args: {
+  memoryId?: string;
+  memoryIds?: string[];
+  attribution?: string;
+}): { memoryIds: string[]; attribution?: string } | null {
+  const ids: string[] = [];
+  if (Array.isArray(args.memoryIds)) {
+    for (const id of args.memoryIds) {
+      if (typeof id === "string" && id.length > 0) ids.push(id);
+    }
+  }
+  if (typeof args.memoryId === "string" && args.memoryId.length > 0) {
+    ids.push(args.memoryId);
+  }
+  const memoryIds = [...new Set(ids)];
+  if (memoryIds.length === 0) return null;
+  const body: { memoryIds: string[]; attribution?: string } = { memoryIds };
+  if (typeof args.attribution === "string" && args.attribution.length > 0) {
+    body.attribution = args.attribution;
+  }
+  return body;
+}
+
+/**
+ * Citation-on-write passthrough. Only returns a list when the caller actually
+ * supplied a non-empty array of non-empty strings — omitted/empty is undefined
+ * so the write body stays byte-identical to a pre-#1147 write.
+ */
+export function citationIds(usedMemoryIds?: string[]): string[] | undefined {
+  if (!Array.isArray(usedMemoryIds) || usedMemoryIds.length === 0) return undefined;
+  if (!usedMemoryIds.every((id) => typeof id === "string" && id.length > 0)) return undefined;
+  return usedMemoryIds;
+}

--- a/packages/flair-mcp/test/usage.test.ts
+++ b/packages/flair-mcp/test/usage.test.ts
@@ -27,9 +27,10 @@ describe("record_usage body (flair#1147)", () => {
   });
 
   test("when BOTH memoryId and memoryIds are supplied, MERGE (do not prefer-and-drop like native /mcp)", () => {
-    // Native resources/mcp-tools.ts recordUsage prefers memoryIds and drops
-    // memoryId when both are present. Stdio merge is deliberate (Sherlock
-    // #1404): silently discarding the singular id would lose a citation.
+    // Native /mcp and RecordUsage.post() PREFER memoryIds (never union).
+    // Stdio merge is load-bearing because it flattens first (Sherlock/Kern
+    // #1404). Native prefer is the pre-existing delivered-but-uncounted
+    // bug tracked in flair#1410 — not this PR's to fix.
     expect(buildRecordUsageBody({ memoryId: "mem-b", memoryIds: ["mem-a"] })).toEqual({
       memoryIds: ["mem-a", "mem-b"],
     });

--- a/packages/flair-mcp/test/usage.test.ts
+++ b/packages/flair-mcp/test/usage.test.ts
@@ -26,9 +26,16 @@ describe("record_usage body (flair#1147)", () => {
     });
   });
 
-  test("singular + plural merge, then dedupe", () => {
+  test("when BOTH memoryId and memoryIds are supplied, MERGE (do not prefer-and-drop like native /mcp)", () => {
+    // Native resources/mcp-tools.ts recordUsage prefers memoryIds and drops
+    // memoryId when both are present. Stdio merge is deliberate (Sherlock
+    // #1404): silently discarding the singular id would lose a citation.
     expect(buildRecordUsageBody({ memoryId: "mem-b", memoryIds: ["mem-a"] })).toEqual({
       memoryIds: ["mem-a", "mem-b"],
+    });
+    // Contrast: native prefer would have returned ["mem-a"] only.
+    expect(buildRecordUsageBody({ memoryId: "mem-solo", memoryIds: ["mem-a", "mem-b"] })).toEqual({
+      memoryIds: ["mem-a", "mem-b", "mem-solo"],
     });
   });
 

--- a/packages/flair-mcp/test/usage.test.ts
+++ b/packages/flair-mcp/test/usage.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildRecordUsageBody,
+  citationIds,
+  CITE_USAGE_NUDGE,
+  withCiteNudge,
+} from "../src/usage.ts";
+
+/**
+ * flair#1147 — stdio MCP clients can reach POST /RecordUsage.
+ *
+ * Pins the body construction the `record_usage` tool uses (identity from the
+ * signature, never the body), the citation-on-write passthrough, and the
+ * one-line cite nudge on recalled ids. Mirrors the isolation style of
+ * mcp.test.ts's coordination-write tests.
+ */
+
+describe("record_usage body (flair#1147)", () => {
+  test("singular memoryId becomes memoryIds — the RecordUsage contract", () => {
+    expect(buildRecordUsageBody({ memoryId: "mem-a" })).toEqual({ memoryIds: ["mem-a"] });
+  });
+
+  test("memoryIds array is forwarded as-is (deduped)", () => {
+    expect(buildRecordUsageBody({ memoryIds: ["mem-a", "mem-b", "mem-a"] })).toEqual({
+      memoryIds: ["mem-a", "mem-b"],
+    });
+  });
+
+  test("singular + plural merge, then dedupe", () => {
+    expect(buildRecordUsageBody({ memoryId: "mem-b", memoryIds: ["mem-a"] })).toEqual({
+      memoryIds: ["mem-a", "mem-b"],
+    });
+  });
+
+  test("optional attribution is forwarded only when non-empty", () => {
+    expect(buildRecordUsageBody({ memoryId: "mem-a", attribution: "grounded the spec" })).toEqual({
+      memoryIds: ["mem-a"],
+      attribution: "grounded the spec",
+    });
+    expect(buildRecordUsageBody({ memoryId: "mem-a", attribution: "" })).toEqual({
+      memoryIds: ["mem-a"],
+    });
+  });
+
+  test("empty / missing ids return null — the tool fails locally, never POSTs an empty list", () => {
+    expect(buildRecordUsageBody({})).toBeNull();
+    expect(buildRecordUsageBody({ memoryIds: [] })).toBeNull();
+    expect(buildRecordUsageBody({ memoryId: "" })).toBeNull();
+  });
+
+  test("body never carries agentId (no forging — attribute from signature)", () => {
+    const body = buildRecordUsageBody({ memoryId: "mem-a", attribution: "used it" });
+    expect(body).not.toBeNull();
+    expect(body).not.toHaveProperty("agentId");
+    expect(Object.keys(body!)).toEqual(["memoryIds", "attribution"]);
+  });
+});
+
+describe("citation-on-write passthrough (flair#1147)", () => {
+  test("forwards a non-empty list of ids", () => {
+    expect(citationIds(["mem-a", "mem-b"])).toEqual(["mem-a", "mem-b"]);
+  });
+
+  test("omitted / empty is undefined so the write body stays byte-identical", () => {
+    expect(citationIds(undefined)).toBeUndefined();
+    expect(citationIds([])).toBeUndefined();
+  });
+
+  test("rejects a list that is not all non-empty strings", () => {
+    expect(citationIds(["mem-a", ""])).toBeUndefined();
+  });
+});
+
+describe("cite-what-you-use nudge (flair#1147)", () => {
+  test("appends the one-line instruction after recalled content", () => {
+    const text = withCiteNudge("1. a recalled memory (id:mem-a)");
+    expect(text).toContain("id:mem-a");
+    expect(text).toContain(CITE_USAGE_NUDGE);
+    expect(text).toContain("record_usage");
+    expect(text).toContain("usedMemoryIds");
+  });
+
+  test("empty text is left empty — no nudge on an empty payload", () => {
+    expect(withCiteNudge("")).toBe("");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1147.

Assigned to @heskew. This PR stays inside that issue's three asks and does not mix #1032, #1012, #1326, #1004, #1122, #1038, #1371, #998, #1248, #1395, or #1397.

## The remaining hole

`POST /RecordUsage` and citation-on-write (`usedMemoryIds` → `recordCitations()`) already exist server-side. Native `/mcp` already exposes `record_usage` and `memory_store.usedMemoryIds` — the 2026-08-14 comment on #1147 was right about that surface.

What the issue originally named was still true on `main`: `packages/flair-mcp/src/index.ts` (the stdio server Claude Code / Cursor actually spawn) had no `record_usage` tool and no citation passthrough. A signed `POST /RecordUsage` was still a hand-roll for those clients.

## What this does

1. **`record_usage` MCP tool** — `memoryId` / `memoryIds` + optional one-line `attribution`. Signed `POST /RecordUsage`. Identity from the signature, never the body.
2. **`usedMemoryIds` passthrough** on `memory_store` / `memory_update` → existing citation-on-write (`usedMemoryIds`, not a new `cites` field). `flair-client` write/update forward the field only when supplied.
3. **One-line cite nudge** on `memory_search` / `bootstrap` output. Ids were already in the payload; a search or bootstrap hit is still not usage.

No new product surface. No SessionStart / REM / ranking changes.

## Named drift: merge vs prefer (Sherlock/Kern #1404)

When **both** `memoryId` and `memoryIds` are supplied:

- `RecordUsage.post()` and native `/mcp` `recordUsage` **prefer** `memoryIds` (`data?.memoryIds ?? …`) and never read `memoryId`. That is **not** a union.
- Stdio `buildRecordUsageBody` **merges** them, then dedupes, and sends only the flattened `memoryIds` array. The merge is load-bearing: without flatten-first, the server would silently drop the singular id (delivered-but-uncounted; empty `memoryIds: []` alongside a real `memoryId` would 400).

Native prefer is a pre-existing delivered-but-uncounted bug on a **different** surface, tracked in #1410 — not a regression from this PR, and not a #1147 blocker. Pinned in `packages/flair-mcp/src/usage.ts` and `test/usage.test.ts`.

## Tests

`packages/flair-mcp/test/usage.test.ts` pins body construction (no `agentId` forge, singular `memoryId`, empty-list refused locally, merge-not-prefer when both fields are set), citation passthrough (omit = byte-identical write), and the cite nudge. `flair-client` tests pin `usedMemoryIds` forwarding on write/update.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f9fd8e8-1699-4a2a-8700-2ae2a720c8bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f9fd8e8-1699-4a2a-8700-2ae2a720c8bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

