### PR TITLE
test: surface darwin-gated launchd tests so they cannot fail a macOS release unseen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,17 +203,29 @@ jobs:
   # "Unit Tests (22)" / "(24)" / "(26)"). This gate job re-emits the fixed
   # "Unit Tests" name and fails unless every matrix leg succeeded, so branch
   # protection needs no change and still genuinely gates on all three majors.
+  #
+  # flair#1012: also needs `test-darwin-gated`. That job is the only lane
+  # that executes the launchd tests. If it is not on this adapter, Linux
+  # unit + this required check stay green on a darwin-only failure and
+  # merge proceeds until `release.sh` on macOS — the gap this issue
+  # exists to close. A new required-check name would need a protection
+  # settings change; folding into "Unit Tests" does not.
   test-unit-gate:
     name: Unit Tests
-    needs: test-unit
+    needs: [test-unit, test-darwin-gated]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: Require all Node-version legs to pass
+      - name: Require all Node-version legs and the darwin-gated lane to pass
         run: |
           echo "test-unit matrix result: ${{ needs.test-unit.result }}"
+          echo "test-darwin-gated result: ${{ needs.test-darwin-gated.result }}"
           if [ "${{ needs.test-unit.result }}" != "success" ]; then
             echo "::error::One or more Unit Tests Node-version legs did not succeed"
+            exit 1
+          fi
+          if [ "${{ needs.test-darwin-gated.result }}" != "success" ]; then
+            echo "::error::Darwin-gated unit tests did not succeed (flair#1012)"
             exit 1
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,16 @@ jobs:
       # (auth scoping, data scoping, REM runner/scheduler/snapshot, content
       # safety, key rotation) with no live-service reason to be excluded.
       - run: bun test test/unit/ test/*.test.ts
+      # flair#1012: darwin-gated tests (`test.skipIf(!isDarwin)`) cover the
+      # launchd branch that unloads production services. They do not execute
+      # on this Linux runner. The suite above reports them as skips, but a
+      # skip buried in thousands of passes is how the original failures sat
+      # on main. This step inventories them, refuses `test.if` (omit), and
+      # fails if the skip count is 0 — "0 darwin tests ran on this platform"
+      # is information; nothing at all is what let #1012 sit. The macOS job
+      # `test-darwin-gated` is the lane that actually runs them.
+      - name: "Darwin-gated unit tests: report skip count (flair#1012)"
+        run: bun scripts/check-darwin-gated-tests.mjs
       # test/unit-isolated/ holds files that `mock.module` a process-global
       # shared module (embeddings-provider). `mock.module` is first-wins and
       # unrestored, so these files poison not only the real-importer files in
@@ -206,6 +216,33 @@ jobs:
             echo "::error::One or more Unit Tests Node-version legs did not succeed"
             exit 1
           fi
+
+  # flair#1012: the launchd branch these tests cover is gated on
+  # `process.platform === "darwin"`. Linux CI skips them (and the unit-lane
+  # step above reports that skip count). This job is the lane that executes
+  # them. A defect here does not produce a Linux failure — it produces a
+  # stopped production instance. Kept to the inventoried darwin-gated files
+  # rather than the whole unit suite so the macOS minutes buy the coverage
+  # that Linux cannot, not a duplicate of test-unit.
+  test-darwin-gated:
+    name: Darwin-gated unit tests
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+      - name: Cache bun install
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-cache-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - name: Run darwin-gated unit tests (must execute, not skip)
+        run: bun scripts/check-darwin-gated-tests.mjs
 
   test-integration:
     name: Integration Tests

--- a/scripts/check-darwin-gated-tests.mjs
+++ b/scripts/check-darwin-gated-tests.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * check-darwin-gated-tests.mjs — flair#1012.
+ *
+ * Darwin-gated unit tests (`test.skipIf(!isDarwin)` and friends) cover the
+ * launchd branch that unloads production services. CI is Linux, so those
+ * tests do not execute there. `release.sh` is the only place they used to
+ * run — on macOS, at the last possible moment — and a `test.if` gate that
+ * *omits* rather than *skips* made the gap look like coverage.
+ *
+ * This script is the Linux-visible half of the fix:
+ *
+ *   1. Inventory every darwin-gated test under test/. An empty inventory is
+ *      a failure (the scan found nothing, so nothing was verified).
+ *   2. Refuse `test.if(<darwin cond>)` / `it.if(...)`. Bun 1.3 reports those
+ *      as skips today, but `if` means "do not define this test" — the form
+ *      that went silent once already. `skipIf` is the form that cannot
+ *      vanish from the tally.
+ *   3. Unless `--inventory-only`, run the inventoried files and require:
+ *        linux  — every inventoried title appears as `(skip)`; print
+ *                 "0 darwin tests ran on this platform" as information.
+ *        darwin — every inventoried title appears as `(pass)`, never skip.
+ *
+ * Usage:
+ *   node scripts/check-darwin-gated-tests.mjs
+ *   node scripts/check-darwin-gated-tests.mjs --inventory-only
+ *   node scripts/check-darwin-gated-tests.mjs --inventory-only --json
+ *
+ * DARWIN_GATE_ROOT overrides the repo root (fixtures).
+ *
+ * Exit codes:
+ *   0 — inventory is non-empty, every gate is skipIf, and (unless
+ *       --inventory-only) this platform's skip/pass contract held
+ *   1 — empty inventory, omit-form gate, skip-count mismatch, or a
+ *       darwin-gated test failed / skipped on darwin
+ */
+
+import { readFileSync, readdirSync, appendFileSync } from "node:fs";
+import { join, relative, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = process.env.DARWIN_GATE_ROOT
+  ? process.env.DARWIN_GATE_ROOT
+  : join(SCRIPT_DIR, "..");
+
+const args = new Set(process.argv.slice(2));
+const inventoryOnly = args.has("--inventory-only");
+const asJson = args.has("--json");
+
+const CALL_KINDS = [
+  { kind: "omit", needle: "test.if(" },
+  { kind: "omit", needle: "it.if(" },
+  { kind: "omit", needle: "describe.if(" },
+  { kind: "skip", needle: "test.skipIf(" },
+  { kind: "skip", needle: "it.skipIf(" },
+  { kind: "skip", needle: "describe.skipIf(" },
+];
+
+function walkTestFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const ent of entries) {
+    if (ent.name === "node_modules" || ent.name === "dist") continue;
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) walkTestFiles(p, out);
+    else if (ent.name.endsWith(".test.ts") || ent.name.endsWith(".test.js")) out.push(p);
+  }
+  return out;
+}
+
+/** True when `idx` is a statement-level call, not a comment or string mention. */
+function isCallSite(src, idx) {
+  let i = idx - 1;
+  while (i >= 0 && src[i] !== "\n") {
+    if (src[i] !== " " && src[i] !== "\t") return false;
+    i--;
+  }
+  return true;
+}
+
+function matchingParen(src, openIdx) {
+  let depth = 0;
+  for (let i = openIdx; i < src.length; i++) {
+    const c = src[i];
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function condMentionsDarwin(cond) {
+  return cond.toLowerCase().includes("darwin");
+}
+
+function extractTitle(src, afterClose) {
+  const rest = src.slice(afterClose + 1);
+  // `test.skipIf(cond)("title", ...)` — skipIf returns the test function.
+  const call = rest.match(/^\s*\(\s*"((?:\\.|[^"\\])*)"/);
+  if (call) return call[1].replace(/\\"/g, '"');
+  // `test.skipIf(cond, "title")` — not used here; accepted so a one-arg
+  // rewrite cannot silently drop the title from the inventory.
+  const comma = rest.match(/^\s*,\s*"((?:\\.|[^"\\])*)"/);
+  if (comma) return comma[1].replace(/\\"/g, '"');
+  return null;
+}
+
+function inventoryDarwinGates(root) {
+  const files = walkTestFiles(join(root, "test"));
+  const tests = [];
+  for (const file of files) {
+    const src = readFileSync(file, "utf8");
+    for (const { kind, needle } of CALL_KINDS) {
+      let from = 0;
+      while (true) {
+        const i = src.indexOf(needle, from);
+        if (i < 0) break;
+        if (!isCallSite(src, i)) {
+          from = i + needle.length;
+          continue;
+        }
+        const open = i + needle.length - 1;
+        const close = matchingParen(src, open);
+        if (close < 0) {
+          from = i + needle.length;
+          continue;
+        }
+        const cond = src.slice(open + 1, close);
+        from = close + 1;
+        if (!condMentionsDarwin(cond)) continue;
+        const title = extractTitle(src, close);
+        tests.push({
+          file: relative(root, file).replaceAll("\\", "/"),
+          title: title ?? "(untitled)",
+          form: kind,
+          cond: cond.trim(),
+        });
+      }
+    }
+  }
+  tests.sort((a, b) => a.file.localeCompare(b.file) || a.title.localeCompare(b.title));
+  return tests;
+}
+
+function printHuman(tests, extraLines = []) {
+  const files = [...new Set(tests.map((t) => t.file))];
+  console.log("Darwin-gated unit tests (flair#1012)");
+  console.log(`platform: ${process.platform}`);
+  console.log(`${tests.length} test(s) in ${files.length} file(s)`);
+  console.log("");
+  let current = "";
+  for (const t of tests) {
+    if (t.file !== current) {
+      current = t.file;
+      console.log(`  ${t.file}`);
+    }
+    console.log(`    - ${t.title}`);
+  }
+  for (const line of extraLines) console.log(line);
+}
+
+function fail(message, tests, extraLines = []) {
+  if (!asJson) {
+    printHuman(tests, extraLines);
+    console.error("");
+    console.error(`❌ ${message}`);
+  } else {
+    console.log(JSON.stringify({ ok: false, error: message, tests }, null, 2));
+  }
+  process.exit(1);
+}
+
+function writeStepSummary(text) {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (!path) return;
+  try {
+    appendFileSync(path, text.endsWith("\n") ? text : `${text}\n`);
+  } catch {
+    /* summary is optional */
+  }
+}
+
+const tests = inventoryDarwinGates(REPO_ROOT);
+
+if (tests.length === 0) {
+  fail(
+    "scanned test/ and found 0 darwin-gated tests — the scan found nothing, so nothing was verified",
+    tests,
+  );
+}
+
+const omit = tests.filter((t) => t.form === "omit");
+if (omit.length > 0) {
+  fail(
+    `${omit.length} darwin-gated test(s) use test.if / it.if / describe.if, which omit the test instead of skipping it. Use test.skipIf(!isDarwin) so Linux CI reports a skip count (flair#1012).`,
+    tests,
+    omit.map((t) => `    omit-form: ${t.file} — ${t.title}`),
+  );
+}
+
+if (inventoryOnly) {
+  if (asJson) {
+    console.log(JSON.stringify({ ok: true, platform: process.platform, tests }, null, 2));
+  } else {
+    printHuman(tests, ["", "inventory-only: skip/pass contract not checked."]);
+  }
+  process.exit(0);
+}
+
+const files = [...new Set(tests.map((t) => t.file))];
+const bun = process.env.BUN_BIN || "bun";
+const ran = spawnSync(bun, ["test", ...files], {
+  cwd: REPO_ROOT,
+  encoding: "utf8",
+  env: process.env,
+});
+const output = `${ran.stdout ?? ""}${ran.stderr ?? ""}`;
+
+function lineKind(line) {
+  if (line.startsWith("(fail) ")) return "fail";
+  if (line.startsWith("(skip) ")) return "skip";
+  if (line.startsWith("(pass) ")) return "pass";
+  return null;
+}
+
+function lineLeaf(line) {
+  // `(skip) describe > title` / `(pass) describe > title [12.3ms]`
+  const rest = line.slice(7); // after "(skip) " / "(pass) " / "(fail) "
+  const timed = rest.lastIndexOf(" [");
+  return timed >= 0 && rest.endsWith("ms]") ? rest.slice(0, timed) : rest;
+}
+
+function statusFor(title) {
+  // Prefer fail > skip > pass so a rerun summary cannot hide a failure.
+  // Leaf match (endsWith the title) so a describe prefix cannot hide it,
+  // and a shorter title cannot match a longer one.
+  let seen = "absent";
+  for (const raw of output.split("\n")) {
+    const line = raw.trimEnd();
+    const kind = lineKind(line);
+    if (!kind) continue;
+    const leaf = lineLeaf(line);
+    if (leaf !== title && !leaf.endsWith(`> ${title}`)) continue;
+    if (kind === "fail") return "fail";
+    if (kind === "skip") seen = "skip";
+    else if (kind === "pass" && seen === "absent") seen = "pass";
+  }
+  return seen;
+}
+
+const results = tests.map((t) => ({ ...t, status: statusFor(t.title) }));
+const skipped = results.filter((t) => t.status === "skip");
+const passed = results.filter((t) => t.status === "pass");
+const failed = results.filter((t) => t.status === "fail");
+const absent = results.filter((t) => t.status === "absent");
+
+const isDarwin = process.platform === "darwin";
+
+if (isDarwin) {
+  const bad = results.filter((t) => t.status !== "pass");
+  if (bad.length > 0 || ran.status !== 0) {
+    fail(
+      `darwin-gated tests must RUN on darwin (flair#1012). ${passed.length} passed, ${skipped.length} skipped, ${failed.length} failed, ${absent.length} absent from bun output.`,
+      tests,
+      [
+        "",
+        output.trimEnd(),
+        "",
+        ...bad.map((t) => `    ${t.status}: ${t.file} — ${t.title}`),
+      ],
+    );
+  }
+  const summary = `${passed.length} darwin-gated unit tests ran on darwin (0 skipped).`;
+  printHuman(tests, ["", summary]);
+  writeStepSummary(`## Darwin-gated unit tests (flair#1012)\n\n${summary}\n`);
+  process.exit(0);
+}
+
+// Linux (and any other non-darwin host): the tests must appear as skips.
+// A universal quantifier over an empty skip list is the original defect.
+if (absent.length > 0 || skipped.length !== tests.length) {
+  fail(
+    `linux must report every darwin-gated test as skipped, not omit it (flair#1012). ${skipped.length} skipped, ${passed.length} passed, ${failed.length} failed, ${absent.length} absent — expected ${tests.length} skipped.`,
+    tests,
+    [
+      "",
+      ...results
+        .filter((t) => t.status !== "skip")
+        .map((t) => `    ${t.status}: ${t.file} — ${t.title}`),
+    ],
+  );
+}
+
+const summary = `${skipped.length} darwin-gated unit tests skipped on ${process.platform}. 0 darwin tests ran on this platform.`;
+printHuman(tests, ["", summary]);
+writeStepSummary(`## Darwin-gated unit tests (flair#1012)\n\n${summary}\n`);
+process.exit(0);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -366,7 +366,29 @@ echo "🧪 Running tests..."
 # 252 tests that no release has ever executed. They pass on macOS in under a
 # second; there was no reason for the omission beyond nobody comparing the two
 # invocations.
-(cd "$ROOT" && bun test test/unit/ test/*.test.ts) || { echo "❌ Tests failed (unit)"; exit 1; }
+# flair#1012: darwin-gated launchd tests are skipped on Linux CI and used
+# to surface only here, on macOS, as a bare "Tests failed" after the full
+# suite. Run the inventory/execution gate first so a darwin-only failure
+# is named as one, and so a Linux release host still reports the skip
+# count instead of looking like those tests do not exist.
+if ! (cd "$ROOT" && node scripts/check-darwin-gated-tests.mjs); then
+  echo "❌ Tests failed (darwin-gated unit tests — flair#1012)"
+  if [[ "$(uname -s)" == Darwin ]]; then
+    echo "   This host is macOS. These tests exercise the launchd branch Linux CI skips."
+    echo "   Compare the failing file against main on this same host before treating it as a release-branch regression."
+  else
+    echo "   This host is not macOS. The gate failed because the skip inventory is broken, not because a launchd test ran."
+  fi
+  exit 1
+fi
+if ! (cd "$ROOT" && bun test test/unit/ test/*.test.ts); then
+  echo "❌ Tests failed (unit)"
+  if [[ "$(uname -s)" == Darwin ]]; then
+    echo "   This host is macOS. The unit suite includes darwin-gated launchd tests that Linux CI skips (flair#1012)."
+    echo "   If the failure is in a darwin-gated file, compare against main on this host — it is not a failure CI would have seen."
+  fi
+  exit 1
+fi
 (cd "$ROOT" && bun test $(find test/integration -name '*.test.ts' | sort)) || { echo "❌ Tests failed (integration)"; exit 1; }
 # test/unit-isolated/ files mock.module a process-global shared module; each
 # MUST run in its own `bun test` process — they poison the real-importer

--- a/test/unit/darwin-gated-visibility.test.ts
+++ b/test/unit/darwin-gated-visibility.test.ts
@@ -1,0 +1,191 @@
+// darwin-gated-visibility.test.ts — flair#1012.
+//
+// Darwin-gated launchd tests failed on macOS and were invisible on Linux CI
+// because `test.if(isDarwin)` made them structurally unreachable on the only
+// platform CI runs. `release.sh` was the first (and last) gate, and it
+// reported a bare "Tests failed".
+//
+// Two properties, both enforced here so the next occurrence cannot hide:
+//
+//   1. The snapshot-targeting tests assert WHICH INSTANCE launchctl named,
+//      not which verb (`stop` vs `unload`). The original failure was a stale
+//      `toContain(\`stop ${scratchLabel}\`)` after quiescing moved to
+//      unload/load. A test that pins the verb would have failed then; a test
+//      that pins the instance would have passed. This file fails if those
+//      verb pins come back.
+//   2. `scripts/check-darwin-gated-tests.mjs` inventories every darwin gate,
+//      refuses `test.if` (omit) in favour of `test.skipIf` (reported skip),
+//      and on Linux requires bun to report a skip per inventoried title.
+//      An empty inventory, an omit-form gate, or a skip count of 0 is a
+//      failure — "nothing at all" is what let #1012 sit.
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "check-darwin-gated-tests.mjs");
+const SNAPSHOT = join(
+  REPO_ROOT,
+  "test",
+  "unit",
+  "snapshot-datadir-instance-targeting.test.ts",
+);
+
+const ORIGINAL_TITLES = [
+  "snapshot restore --data-dir <scratch> resolves the SCRATCH instance's launchd label, never the default install's",
+  "snapshot create --data-dir <scratch> quiesces the SCRATCH instance around the snapshot",
+];
+
+function runGate(
+  extraArgs: string[] = [],
+  opts: { root?: string } = {},
+): { status: number | null; out: string } {
+  const r = spawnSync(process.execPath, [SCRIPT, ...extraArgs], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DARWIN_GATE_ROOT: opts.root ?? REPO_ROOT,
+      GITHUB_STEP_SUMMARY: "",
+    },
+  });
+  return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+function fixture(contents: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "flair1012-"));
+  for (const [rel, body] of Object.entries(contents)) {
+    const path = join(dir, rel);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, body);
+  }
+  return dir;
+}
+
+describe("flair#1012 — snapshot targeting pins the instance, not the verb", () => {
+  const src = readFileSync(SNAPSHOT, "utf8");
+
+  test("expectLaunchctlNamedOnly is the assertion both darwin cases use", () => {
+    expect(src).toContain("function expectLaunchctlNamedOnly");
+    const uses = src.split("expectLaunchctlNamedOnly({ label: scratchLabel").length - 1;
+    expect(uses).toBe(2);
+  });
+
+  test("the original verb pins that failed on macOS are gone", () => {
+    // The #1012 failure, verbatim:
+    //   expect(invocations).toContain(`stop ${scratchLabel}`);
+    //   expect(invocations).toContain(`start ${scratchLabel}`);
+    // Those pins broke when quiescing moved to unload/load and the targeting
+    // they existed to protect was still holding. String scan, not regex —
+    // the same discipline as the other tripwires.
+    expect(src.includes("toContain(`stop ${scratchLabel}`)")).toBe(false);
+    expect(src.includes("toContain(`start ${scratchLabel}`)")).toBe(false);
+    expect(src.includes('toContain("stop ai.tpsdev.flair.')).toBe(false);
+  });
+});
+
+describe("check-darwin-gated-tests.mjs inventory (real repo)", () => {
+  const res = runGate(["--inventory-only", "--json"]);
+  const body = (() => {
+    try {
+      return JSON.parse(res.out) as {
+        ok: boolean;
+        tests: Array<{ file: string; title: string; form: string }>;
+      };
+    } catch {
+      return null;
+    }
+  })();
+
+  test("exits 0", () => {
+    expect(res.status).toBe(0);
+    expect(body?.ok).toBe(true);
+  });
+
+  test("finds the two #1012 snapshot cases and reports them as skip-form", () => {
+    expect(body).not.toBeNull();
+    const titles = (body?.tests ?? []).map((t) => t.title);
+    for (const title of ORIGINAL_TITLES) {
+      expect(titles).toContain(title);
+    }
+    const snapshot = (body?.tests ?? []).filter((t) =>
+      t.file.endsWith("snapshot-datadir-instance-targeting.test.ts"),
+    );
+    expect(snapshot.length).toBeGreaterThanOrEqual(2);
+    expect(snapshot.every((t) => t.form === "skip")).toBe(true);
+  });
+
+  test("inventory is non-empty and uses skipIf, not if", () => {
+    expect((body?.tests ?? []).length).toBeGreaterThanOrEqual(9);
+    expect((body?.tests ?? []).every((t) => t.form === "skip")).toBe(true);
+    const files = new Set((body?.tests ?? []).map((t) => t.file));
+    expect(files.has("test/unit/snapshot-datadir-instance-targeting.test.ts")).toBe(true);
+    expect(files.has("test/unit/launchd-management-reporting.test.ts")).toBe(true);
+    expect(files.has("test/unit/harper-config-port.test.ts")).toBe(true);
+  });
+});
+
+describe("check-darwin-gated-tests.mjs refuses a silent omit", () => {
+  test("test.if(isDarwin) fails the gate", () => {
+    const dir = fixture({
+      "test/unit/omit.test.ts": [
+        `import { test, expect } from "bun:test";`,
+        `const isDarwin = process.platform === "darwin";`,
+        `test.if(isDarwin)("hidden darwin case", () => { expect(true).toBe(true); });`,
+        `test("always", () => { expect(true).toBe(true); });`,
+        "",
+      ].join("\n"),
+    });
+    try {
+      const res = runGate(["--inventory-only"], { root: dir });
+      expect(res.status).not.toBe(0);
+      expect(res.out).toContain("test.if");
+      expect(res.out).toContain("hidden darwin case");
+      expect(res.out).toContain("skipIf");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("an empty test/ is a failure, not a clean scan", () => {
+    const dir = fixture({ "test/.keep": "" });
+    try {
+      const res = runGate(["--inventory-only"], { root: dir });
+      expect(res.status).not.toBe(0);
+      expect(res.out).toContain("0 darwin-gated tests");
+      expect(res.out).toContain("nothing was verified");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-darwin-gated-tests.mjs skip count on this platform", () => {
+  test("skipIf is reported as skipped on linux (and the count is asserted)", () => {
+    const dir = fixture({
+      "test/unit/visible.test.ts": [
+        `import { test, expect } from "bun:test";`,
+        `const isDarwin = process.platform === "darwin";`,
+        `test.skipIf(!isDarwin)("visible darwin case", () => { expect(true).toBe(true); });`,
+        `test("always", () => { expect(true).toBe(true); });`,
+        "",
+      ].join("\n"),
+    });
+    try {
+      const res = runGate([], { root: dir });
+      if (process.platform === "darwin") {
+        expect(res.status).toBe(0);
+        expect(res.out).toContain("1 darwin-gated unit tests ran on darwin");
+        expect(res.out).not.toContain("0 darwin tests ran on this platform");
+      } else {
+        expect(res.status).toBe(0);
+        expect(res.out).toContain("1 darwin-gated unit tests skipped");
+        expect(res.out).toContain("0 darwin tests ran on this platform");
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/test/unit/harper-config-port.test.ts
+++ b/test/unit/harper-config-port.test.ts
@@ -583,7 +583,7 @@ describe("flair#914 — an instance's port comes from Harper's config in its dat
   // spawns a real Harper and waits a minute for health. Gating beats spawning a
   // database in a unit test.
 
-  test.if(process.platform === "darwin")(
+  test.skipIf(process.platform !== "darwin")(
     "restoring a snapshot acts on the target instance and never on the source's port",
     async () => {
       // A snapshot is a byte-exact copy of a data directory, so it carries the

--- a/test/unit/launchd-management-reporting.test.ts
+++ b/test/unit/launchd-management-reporting.test.ts
@@ -49,9 +49,10 @@
 //     succeeds against the shim + stub, or the run aborts before the start leg.
 //
 // COVERAGE — the end-to-end half of this file is darwin-only, because the code
-// it exercises is gated on `process.platform === "darwin"` and CI runs Linux.
-// Nothing in CI will ever run it. The pure tests are deliberately
-// platform-independent so at least the decision logic is gated somewhere.
+// it exercises is gated on `process.platform === "darwin"`. Linux CI reports
+// those cases as skipped (`test.skipIf(!isDarwin)`, flair#1012); the
+// darwin-gated unit-test lane is what executes them. The pure tests are
+// deliberately platform-independent so the decision logic is gated everywhere.
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, cpSync } from "node:fs";
 import { join } from "node:path";
@@ -651,7 +652,7 @@ describe("flair#1022 — `flair restart` reports the launchd outcome, not just l
     }));
   }
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "THE DEFECT: a restart that ends with the instance outside launchd does NOT report unqualified success",
     async () => {
       writeHealthyPlist();
@@ -689,7 +690,7 @@ describe("flair#1022 — `flair restart` reports the launchd outcome, not just l
     30_000,
   );
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "POSITIVE CONTROL: a clean restart, still managed by launchd, still reports success",
     async () => {
       writeHealthyPlist();
@@ -713,7 +714,7 @@ describe("flair#1022 — `flair restart` reports the launchd outcome, not just l
     30_000,
   );
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "THE FIRST 60-SECOND WAIT: the stop leg does not wait on a process launchd is not running",
     async () => {
       // The incident's first hang: "launchd stop failed, falling back to
@@ -769,7 +770,7 @@ describe("flair#1022 — `flair restart` reports the launchd outcome, not just l
     60_000,
   );
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "THE 60-SECOND WAIT: a stale plist aborts the launchd start immediately, naming the path and the fix",
     async () => {
       // The start leg is the half that produced
@@ -830,7 +831,7 @@ describe("flair#1022 — `flair restart` reports the launchd outcome, not just l
     60_000,
   );
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "every launchctl invocation names this fixture's instance — never a real install",
     async () => {
       writeHealthyPlist();

--- a/test/unit/snapshot-datadir-instance-targeting.test.ts
+++ b/test/unit/snapshot-datadir-instance-targeting.test.ts
@@ -34,11 +34,12 @@
 // `--data-dir` pointed at, and none names the default install.
 //
 // The launchd tests are darwin-only because `stopFlairProcess`'s launchd
-// branch is itself gated on `process.platform === "darwin"`. CI runs on
-// ubuntu, where the port-based path is the ONLY path — which is why the
-// port-attribution test below is deliberately platform-independent: it is
-// both the Linux face of this bug and the one that catches the regression
-// everywhere.
+// branch is itself gated on `process.platform === "darwin"`. They use
+// `test.skipIf(!isDarwin)` so Linux CI reports them as skipped (flair#1012)
+// rather than omitting them. The darwin-gated lane and `scripts/release.sh`
+// are what actually execute them. The port-attribution test below is
+// deliberately platform-independent: it is both the Linux face of this bug
+// and the one that catches the regression everywhere.
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
@@ -201,7 +202,7 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
 
   // ─── the headline defect, end to end ────────────────────────────────────
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "snapshot restore --data-dir <scratch> resolves the SCRATCH instance's launchd label, never the default install's",
     async () => {
       const scratchLabel = launchdLabel(scratchDataDir);
@@ -243,7 +244,7 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
     },
   );
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "snapshot create --data-dir <scratch> quiesces the SCRATCH instance around the snapshot",
     async () => {
       const scratchLabel = launchdLabel(scratchDataDir);
@@ -269,7 +270,7 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
 
   // ─── the pre-flair#693 legacy label, which is global to the whole user ──
 
-  test.if(isDarwin)(
+  test.skipIf(!isDarwin)(
     "refuses to stop the legacy launchd service when its plist belongs to another data dir",
     async () => {
       // `ai.tpsdev.flair` is a single label for the whole login session, so


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1012.

#1012 is already assigned to @heskew.

One issue only. Does not mix #1032, #1326, #1004, #1147, #1122, #1038, #1371, #998, #1248, #1395, or #1397.

## What was left after #1013

#1013 rewrote the two snapshot-targeting assertions so they pin **which instance** launchctl named, not which verb (`stop` vs `unload`). That unblocked the assertions themselves. It deliberately did **not** close #1012: the tests were still `test.if(isDarwin)`, Linux CI still never executed them, and `release.sh` on macOS was still the first place a failure showed up — as a bare `❌ Tests failed` after the full suite.

The safety property those tests exist to protect is already holding (confirmed in #1013). This PR is the coverage gap.

## What changed

1. **`test.if(isDarwin)` → `test.skipIf(!isDarwin)`** in the three files that gate on darwin (`snapshot-datadir-instance-targeting`, `launchd-management-reporting`, `harper-config-port`). `if` means "do not define this test"; `skipIf` means "count it as skipped." Linux CI now has a skip tally instead of a hole.

2. **`scripts/check-darwin-gated-tests.mjs`** inventories every darwin-gated test under `test/`. An empty inventory is a failure. `test.if` / `it.if` / `describe.if` on a darwin condition is a failure (the omit form). On Linux it runs the inventoried files and requires every title to appear as `(skip)` — *"0 darwin tests ran on this platform"* is printed as information. On darwin it requires every title to `(pass)`.

3. **Linux unit lane** runs that script as its own step, so the skip count is a first-class CI line, not a number buried in thousands of passes.

4. **`test-darwin-gated` job** on `macos-latest` is the lane that actually executes them. Scoped to the inventoried files, not a duplicate of the whole unit suite.

5. **`release.sh`** runs the same gate *before* the unit suite and names a darwin-gated failure as one. A later unit-suite failure on macOS also says that darwin-gated launchd tests ran here and are skipped on Linux CI — so "your change broke something" is distinguishable from "main has been failing on this platform."

## The test that would have caught the original failure

`test/unit/darwin-gated-visibility.test.ts` fails if the two #1012 snapshot cases go back to `toContain(\`stop ${scratchLabel}\`)` / `toContain(\`start ${scratchLabel}\`)`, and fails if the inventory is empty or a new darwin gate uses `test.if`. That check runs on Linux.

## Testing

On this Linux host:

| Check | Result |
| --- | --- |
| `node scripts/check-darwin-gated-tests.mjs --inventory-only` | 9 tests in 3 files |
| `node scripts/check-darwin-gated-tests.mjs` | `9 darwin-gated unit tests skipped on linux. 0 darwin tests ran on this platform.` |
| `bun test test/unit/darwin-gated-visibility.test.ts` | 8 pass / 0 fail |
| The three gated files + the new tripwire | 53 pass / 9 skip / 0 fail |

The macOS job is what executes the 9 skipped cases. Not run here (this host is Linux).

## Changelog

None. Test/CI/release-script diagnostics — not user-visible. Same call #1013 made for the assertion rewrite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-838ccb03-f723-4c8f-abc9-79469bade65b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-838ccb03-f723-4c8f-abc9-79469bade65b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

