### PR TITLE
fix(health): /Health names search readiness instead of a lying green light

### DIFF
--- a/.changelog/unreleased/fixed-1326-health-search-ready.md
+++ b/.changelog/unreleased/fixed-1326-health-search-ready.md
@@ -1,0 +1,8 @@
+- **`/Health` no longer reports a node as healthy when search is not actually usable** (flair#1326).
+  After restart, Harper can answer `/health` in a few seconds while `/Memory`
+  and `/SemanticSearch` are still catch-all 404s, and while the hybrid BM25
+  index is still empty (the first search scans the corpus; that lag grows with
+  store size). `/Health` now always includes `searchReady`. Missing search
+  routes return HTTP 503 and `ok: false`. A live process with a cold index
+  stays 200 and names the lag on `searchReadyReason` so a traffic gate can
+  tell "up" from "recall-ready." `/HealthDetail` carries the same fields.

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -1,4 +1,4 @@
-import { Resource, databases, server } from "harper";
+import { Resource, databases, server, logger } from "harper";
 import { promises as fsp, existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, dirname } from "node:path";
@@ -119,8 +119,18 @@ export class Health extends Resource {
 }
 
 /** Same sources /Health and /HealthDetail consult so they cannot disagree. */
+let _warnedMissingRegistry = false;
 function currentSearchReadiness(): SearchReadiness {
+  // Shipped Harper launch: this Resource is already registered, so
+  // server.resources is populated. The null skip is a stated fail-open
+  // (Sherlock on #1406) for the injectable/test path — not an accident.
   const resources = (server as { resources?: ResourceRegistry }).resources ?? null;
+  if (!resources && !_warnedMissingRegistry) {
+    _warnedMissingRegistry = true;
+    logger.warn?.(
+      "Health: server.resources is absent — skipping the search-route mount check (table-only fail-open). Shipped Harper launch always exposes the registry.",
+    );
+  }
   return resolveSearchReadiness({
     resources,
     memoryTable: db.flair?.Memory,

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -9,7 +9,7 @@ import { getMigrationStatusSnapshot } from "./migrations/status.js";
 import { resolveMigrationDataDirForRead } from "./migrations/data-dir.js";
 import { REM_DEDUP_STATS_PATH } from "./dedup-cluster.js";
 import { hybridEnabled } from "./bm25.js";
-import { bm25IndexStatus } from "./bm25-index-service.js";
+import { bm25IndexEnabled, bm25IndexStatus } from "./bm25-index-service.js";
 import { buildPublicHealthBody, resolveSearchReadiness, type ResourceRegistry, type SearchReadiness } from "./search-readiness.js";
 
 const db = databases as any;
@@ -126,6 +126,7 @@ function currentSearchReadiness(): SearchReadiness {
     memoryTable: db.flair?.Memory,
     bm25: bm25IndexStatus(),
     hybridEnabled: hybridEnabled(),
+    bm25IndexEnabled: bm25IndexEnabled(),
   });
 }
 

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -1,4 +1,4 @@
-import { Resource, databases } from "harper";
+import { Resource, databases, server } from "harper";
 import { promises as fsp, existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, dirname } from "node:path";
@@ -8,6 +8,9 @@ import { resolveBuildInfo } from "./build-info.js";
 import { getMigrationStatusSnapshot } from "./migrations/status.js";
 import { resolveMigrationDataDirForRead } from "./migrations/data-dir.js";
 import { REM_DEDUP_STATS_PATH } from "./dedup-cluster.js";
+import { hybridEnabled } from "./bm25.js";
+import { bm25IndexStatus } from "./bm25-index-service.js";
+import { buildPublicHealthBody, resolveSearchReadiness, type ResourceRegistry, type SearchReadiness } from "./search-readiness.js";
 
 const db = databases as any;
 
@@ -49,7 +52,7 @@ function resolveVersion(): string {
 }
 
 /**
- * Health endpoint — truly public, returns only { ok: true }.
+ * Health endpoint — truly public. Identity-free; no auth, no role check.
  *
  * `allowRead() { return true }` opens Harper's role gate for anonymous GETs,
  * which is what makes /Health work for callers outside `authorizeLocal`'s
@@ -63,8 +66,15 @@ function resolveVersion(): string {
  *
  * Same pattern as `FederationPair.allowCreate(){ return true }` (PR #299):
  * declare the Resource anonymously-accessible at the Harper layer; let the
- * handler itself enforce whatever it needs (in this case, nothing — /Health
- * is intentionally and always public).
+ * handler itself enforce whatever it needs.
+ *
+ * flair#1326: `ok: true` used to mean only "this resource answered." That
+ * is a green light that lies when search routes are not mounted yet, or
+ * when the hybrid BM25 index is still cold (first search after restart
+ * scans the corpus; the lag grows with store size). `searchReady` is
+ * always present. When search cannot be served at all, this endpoint
+ * returns HTTP 503 and `ok: false`. When the process is live but recall
+ * is still cold, it stays 200 and names the lag on `searchReadyReason`.
  *
  * Rich stats (memory counts, agent names, etc.) are behind /HealthDetail
  * which requires authentication. This prevents information leakage on
@@ -93,12 +103,30 @@ export class Health extends Resource {
     // a 40-hex sha when the build ran in a git work tree, an honest null
     // otherwise (tarball builds) — never omitted, never fabricated (Sherlock).
     const build = resolveBuildInfo();
-    return {
-      ok: true,
+    const readiness = currentSearchReadiness();
+    const body = buildPublicHealthBody(readiness, {
       version: build?.version ?? resolveVersion(),
       buildCommit: build?.commit ?? null,
-    };
+    });
+    if (readiness.status !== 200) {
+      return new Response(JSON.stringify(body), {
+        status: readiness.status,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return body;
   }
+}
+
+/** Same sources /Health and /HealthDetail consult so they cannot disagree. */
+function currentSearchReadiness(): SearchReadiness {
+  const resources = (server as { resources?: ResourceRegistry }).resources ?? null;
+  return resolveSearchReadiness({
+    resources,
+    memoryTable: db.flair?.Memory,
+    bm25: bm25IndexStatus(),
+    hybridEnabled: hybridEnabled(),
+  });
 }
 
 /**
@@ -126,6 +154,16 @@ export class HealthDetail extends Resource {
     const stats: Record<string, any> = { ok: true };
     const nowMs = Date.now();
     const warnings: Array<{ level: "warn" | "info"; message: string }> = [];
+
+    // flair#1326: same search-ready signal as public /Health. HealthDetail
+    // stays HTTP 200 (it is a stats dump, not a traffic gate); the field
+    // and a warning name the lag so `flair status` / operators can see it.
+    const readiness = currentSearchReadiness();
+    stats.searchReady = readiness.searchReady;
+    if (readiness.searchReadyReason) {
+      stats.searchReadyReason = readiness.searchReadyReason;
+      warnings.push({ level: "warn", message: readiness.searchReadyReason });
+    }
 
     const ctx = (this as any).getContext?.();
     // #614 fix: resolve identity via the shared three-way verdict

--- a/resources/search-readiness.ts
+++ b/resources/search-readiness.ts
@@ -63,9 +63,14 @@ function routeMounted(resources: ResourceRegistry, name: string): boolean {
  * Decide whether search is actually usable, and whether /Health should claim
  * the process is healthy.
  *
- * `resources` is optional: Harper's `server` export may not expose the
- * registry in every context. When it is missing we skip the route check
- * rather than fail-closed forever. The memory-table check still applies.
+ * `resources` is optional. Stated fail-open (Sherlock on #1406): when the
+ * registry is missing we skip the route-mount check rather than 503 forever.
+ * A table handle can exist while `/Memory` and `/SemanticSearch` still 404,
+ * so this is weaker than the primary defense. In the shipped launch path
+ * `/Health` is served by this Resource after Harper has registered us, so
+ * `server.resources` is populated; the skip is the injectable/test path
+ * (and a theoretical export without a registry). Health.ts logs once if
+ * the live call site actually takes it.
  */
 export function resolveSearchReadiness(opts: {
   resources?: ResourceRegistry | null;

--- a/resources/search-readiness.ts
+++ b/resources/search-readiness.ts
@@ -1,0 +1,129 @@
+/**
+ * search-readiness.ts — the honest /Health search-ready signal (flair#1326).
+ *
+ * Harper's process can answer /health (and Flair's /Health resource can
+ * answer {ok:true}) while search is still unusable:
+ *
+ *   1. Boot window — jsResources register incrementally. /Health can be up
+ *      while /Memory and /SemanticSearch still 404 from Harper's catch-all
+ *      (documented in packages/adk-flair-js/test/helpers/boot-harper.mjs).
+ *   2. Cold BM25 index — hybrid retrieval's persistent index is lazy-built
+ *      on the first search, not at component start (bm25-index-service.ts).
+ *      That first-query corpus scan grows with store size. /Health answering
+ *      is not "recall is warm."
+ *
+ * This module is Harper-free so the decision is unit-testable against the
+ * shipped function. Callers inject the registry / table / index status they
+ * already have.
+ *
+ * Two layers, on purpose:
+ *   - Routes/table not mounted → not healthy (ok:false, HTTP 503). A
+ *     traffic-gating probe that only looks at status must not get a green
+ *     light for a node whose search routes are not serving.
+ *   - Routes up but index still cold → process is live (ok:true, HTTP 200)
+ *     and searchReady:false names the lag. We do NOT 503 on a cold index:
+ *     the index builds on the first search, and a health check must not
+ *     trigger that scan (bm25-index-service.ts: "Eager building would add a
+ *     full corpus scan to every boot including … health checks"). 503-until-
+ *     warm would deadlock — health waits for the index, the index waits for
+ *     a search that never comes.
+ */
+
+export type SearchReadiness = {
+  /** False when search routes/table are down OR the hybrid index is still cold. */
+  searchReady: boolean;
+  /** Liveness: the Flair app can answer. False only when search cannot be served at all. */
+  ok: boolean;
+  /** HTTP status for the public /Health endpoint. */
+  status: number;
+  /** Present iff !searchReady — names the lag instead of implying "healthy." */
+  searchReadyReason?: string;
+};
+
+export type ResourceRegistry = {
+  get?(name: string): { Resource?: unknown } | undefined;
+  getMatch?(name: string): { Resource?: unknown } | undefined;
+};
+
+export type MemoryTable = {
+  search?: (query: unknown) => unknown;
+} | null | undefined;
+
+export type Bm25Status = {
+  state: string;
+  reason?: string;
+} | null | undefined;
+
+function routeMounted(resources: ResourceRegistry, name: string): boolean {
+  const entry = resources.get?.(name) ?? resources.getMatch?.(name);
+  return Boolean(entry?.Resource);
+}
+
+/**
+ * Decide whether search is actually usable, and whether /Health should claim
+ * the process is healthy.
+ *
+ * `resources` is optional: Harper's `server` export may not expose the
+ * registry in every context. When it is missing we skip the route check
+ * rather than fail-closed forever. The memory-table check still applies.
+ */
+export function resolveSearchReadiness(opts: {
+  resources?: ResourceRegistry | null;
+  memoryTable?: MemoryTable;
+  bm25?: Bm25Status;
+  hybridEnabled?: boolean;
+}): SearchReadiness {
+  if (opts.resources) {
+    const memoryMounted = routeMounted(opts.resources, "Memory");
+    const searchMounted = routeMounted(opts.resources, "SemanticSearch");
+    if (!memoryMounted || !searchMounted) {
+      const missing = [
+        !memoryMounted ? "Memory" : null,
+        !searchMounted ? "SemanticSearch" : null,
+      ].filter(Boolean).join(", ");
+      return notServing(`search routes not mounted (${missing})`);
+    }
+  }
+
+  if (!opts.memoryTable || typeof opts.memoryTable.search !== "function") {
+    return notServing("memory table not queryable");
+  }
+
+  // Hybrid is default-on. A cold or in-flight BM25 index means the first
+  // search will pay a full corpus scan — the #1326 lag. Name it; do not
+  // fail liveness. `disabled` falls back to the per-query scan (slow but
+  // serving), so that is still search-ready.
+  if (opts.hybridEnabled !== false && opts.bm25) {
+    if (opts.bm25.state === "building") {
+      return namesLag("bm25 index building — first search is still scanning the corpus");
+    }
+    if (opts.bm25.state === "empty") {
+      return namesLag("bm25 index not built (cold boot; first search scans the corpus)");
+    }
+  }
+
+  return { searchReady: true, ok: true, status: 200 };
+}
+
+function notServing(searchReadyReason: string): SearchReadiness {
+  return { searchReady: false, ok: false, status: 503, searchReadyReason };
+}
+
+function namesLag(searchReadyReason: string): SearchReadiness {
+  return { searchReady: false, ok: true, status: 200, searchReadyReason };
+}
+
+/** Public /Health JSON body. `searchReady` is always present (never omitted). */
+export function buildPublicHealthBody(
+  readiness: SearchReadiness,
+  identity: { version: string; buildCommit: string | null },
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    ok: readiness.ok,
+    version: identity.version,
+    buildCommit: identity.buildCommit,
+    searchReady: readiness.searchReady,
+  };
+  if (readiness.searchReadyReason) body.searchReadyReason = readiness.searchReadyReason;
+  return body;
+}

--- a/resources/search-readiness.ts
+++ b/resources/search-readiness.ts
@@ -72,6 +72,8 @@ export function resolveSearchReadiness(opts: {
   memoryTable?: MemoryTable;
   bm25?: Bm25Status;
   hybridEnabled?: boolean;
+  /** Persistent BM25 index kill switch (`FLAIR_BM25_INDEX`). Default on. */
+  bm25IndexEnabled?: boolean;
 }): SearchReadiness {
   if (opts.resources) {
     const memoryMounted = routeMounted(opts.resources, "Memory");
@@ -89,11 +91,17 @@ export function resolveSearchReadiness(opts: {
     return notServing("memory table not queryable");
   }
 
-  // Hybrid is default-on. A cold or in-flight BM25 index means the first
-  // search will pay a full corpus scan — the #1326 lag. Name it; do not
-  // fail liveness. `disabled` falls back to the per-query scan (slow but
-  // serving), so that is still search-ready.
-  if (opts.hybridEnabled !== false && opts.bm25) {
+  // Hybrid + the persistent index are default-on. A cold or in-flight BM25
+  // index means the first search will pay a full corpus scan — the #1326
+  // lag. Name it; do not fail liveness.
+  //
+  // `disabled` (feed/build failure) and `FLAIR_BM25_INDEX=false` both fall
+  // back to the per-query scan. The kill switch never calls ensureReady, so
+  // status stays `empty` for the life of the process — that is serving, not
+  // cold. Treating it as lag would make searchReady false forever and refuse
+  // a node that is already answering recall.
+  const indexInPath = opts.hybridEnabled !== false && opts.bm25IndexEnabled !== false;
+  if (indexInPath && opts.bm25) {
     if (opts.bm25.state === "building") {
       return namesLag("bm25 index building — first search is still scanning the corpus");
     }

--- a/test/integration/health-build-info-e2e.test.ts
+++ b/test/integration/health-build-info-e2e.test.ts
@@ -61,8 +61,21 @@ describe("/Health serves the build's own identity (flair#1076)", () => {
   test("GET /Health: version and buildCommit come from the stamp the running server loaded", async () => {
     const res = await fetch(`${harper.httpURL}/Health`);
     expect(res.ok).toBe(true);
-    const body = (await res.json()) as { ok?: boolean; version?: string; buildCommit?: string | null };
+    const body = (await res.json()) as {
+      ok?: boolean;
+      version?: string;
+      buildCommit?: string | null;
+      searchReady?: boolean;
+      searchReadyReason?: string;
+    };
     expect(body.ok).toBe(true);
+    // flair#1326: searchReady is always present. After a fresh startHarper
+    // the BM25 index is still cold, so false + a reason is the honest
+    // reading; if something warmed it, true with no reason is also fine.
+    expect(typeof body.searchReady).toBe("boolean");
+    if (body.searchReady === false) {
+      expect(body.searchReadyReason).toMatch(/bm25|not mounted|not queryable/i);
+    }
     // Sherlock's honesty ruling: the field is ALWAYS present — a tarball
     // build renders null, but the key is never silently omitted.
     expect("buildCommit" in body).toBe(true);

--- a/test/unit/resource-allow-decision.test.ts
+++ b/test/unit/resource-allow-decision.test.ts
@@ -217,7 +217,7 @@ describe("every Resource under resources/*.ts declares an explicit allow-decisio
  * self-verify (signature / token) or genuinely not need identity at all.
  */
 const EARLY_RETURN_ENDPOINTS: Array<{ path: string; file: string; className: string; note: string }> = [
-  { path: "/health, /Health", file: "health.ts", className: "Health", note: "genuinely identity-free — returns only {ok:true}" },
+  { path: "/health, /Health", file: "health.ts", className: "Health", note: "genuinely identity-free — {ok, version, buildCommit, searchReady}; no caller identity" },
   { path: "GET /a2a, /A2AAdapter*", file: "A2AAdapter.ts", className: "A2AAdapter", note: "public agent-card metadata; POST is NOT early-returned and goes through the general middleware path" },
   { path: "/AgentCard*", file: "AgentCard.ts", className: "AgentCard", note: "public discovery metadata, per A2A spec" },
   { path: "/FederationSync", file: "Federation.ts", className: "FederationSync", note: "self-verifies via verifyBodySignatureFresh (Ed25519 body signature + anti-replay)" },

--- a/test/unit/search-readiness.test.ts
+++ b/test/unit/search-readiness.test.ts
@@ -1,0 +1,186 @@
+/**
+ * search-readiness.test.ts — flair#1326.
+ *
+ * /Health used to answer {ok:true} as soon as the Health resource was
+ * loaded. That is a green light that lies when /Memory and /SemanticSearch
+ * are still Harper catch-all 404s, and again after restart when the hybrid
+ * BM25 index is still empty (first search scans the corpus; the lag grows
+ * with store size). The decision lives in resources/search-readiness.ts so
+ * this file drives the shipped function — no Harper, no 66k-row store.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  buildPublicHealthBody,
+  resolveSearchReadiness,
+  type ResourceRegistry,
+} from "../../resources/search-readiness.ts";
+
+function registry(names: string[]): ResourceRegistry {
+  const set = new Set(names);
+  return {
+    get: (name) => (set.has(name) ? { Resource: class {} } : undefined),
+  };
+}
+
+const memoryTable = { search: () => ({}) };
+const mounted = registry(["Memory", "SemanticSearch"]);
+
+describe("resolveSearchReadiness (flair#1326)", () => {
+  test("routes not mounted → not healthy (503), reason names the missing route", () => {
+    const r = resolveSearchReadiness({
+      resources: registry(["Health"]),
+      memoryTable,
+      bm25: { state: "ready" },
+      hybridEnabled: true,
+    });
+    expect(r).toEqual({
+      searchReady: false,
+      ok: false,
+      status: 503,
+      searchReadyReason: "search routes not mounted (Memory, SemanticSearch)",
+    });
+  });
+
+  test("only Memory mounted → 503 names SemanticSearch, not a blanket healthy", () => {
+    const r = resolveSearchReadiness({
+      resources: registry(["Memory"]),
+      memoryTable,
+      bm25: { state: "ready" },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(503);
+    expect(r.searchReady).toBe(false);
+    expect(r.searchReadyReason).toBe("search routes not mounted (SemanticSearch)");
+  });
+
+  test("memory table not queryable → 503 even when routes look mounted", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable: {},
+      bm25: { state: "ready" },
+    });
+    expect(r).toEqual({
+      searchReady: false,
+      ok: false,
+      status: 503,
+      searchReadyReason: "memory table not queryable",
+    });
+  });
+
+  test("no registry (Harper server.resources absent) does not fail-closed if the table answers", () => {
+    const r = resolveSearchReadiness({
+      resources: null,
+      memoryTable,
+      bm25: { state: "ready" },
+      hybridEnabled: true,
+    });
+    expect(r).toEqual({ searchReady: true, ok: true, status: 200 });
+  });
+
+  test("cold BM25 index after restart → 200 liveness, searchReady false names the lag", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "empty" },
+      hybridEnabled: true,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.searchReady).toBe(false);
+    expect(r.searchReadyReason).toMatch(/bm25 index not built/i);
+    expect(r.searchReadyReason).toMatch(/first search scans the corpus/i);
+  });
+
+  test("BM25 still building → names the in-flight scan, does not claim search-ready", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "building" },
+      hybridEnabled: true,
+    });
+    expect(r.searchReady).toBe(false);
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.searchReadyReason).toMatch(/bm25 index building/i);
+  });
+
+  test("BM25 ready + routes mounted → searchReady true, no reason", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "ready" },
+      hybridEnabled: true,
+    });
+    expect(r).toEqual({ searchReady: true, ok: true, status: 200 });
+    expect(r.searchReadyReason).toBeUndefined();
+  });
+
+  test("hybrid off: a cold BM25 index is not a lie — lexical fallback is the path", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "empty" },
+      hybridEnabled: false,
+    });
+    expect(r.searchReady).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+  });
+
+  test("BM25 disabled (legacy per-query scan) is still serving, so searchReady stays true", () => {
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "disabled", reason: "change feed ended" },
+      hybridEnabled: true,
+    });
+    expect(r.searchReady).toBe(true);
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("buildPublicHealthBody (flair#1326)", () => {
+  const identity = { version: "0.46.0", buildCommit: "a".repeat(40) };
+
+  test("searchReady is always present — never omitted the way a silent green light was", () => {
+    const ready = buildPublicHealthBody(
+      { searchReady: true, ok: true, status: 200 },
+      identity,
+    );
+    expect(ready).toEqual({
+      ok: true,
+      version: "0.46.0",
+      buildCommit: identity.buildCommit,
+      searchReady: true,
+    });
+    expect("searchReadyReason" in ready).toBe(false);
+
+    const cold = buildPublicHealthBody(
+      {
+        searchReady: false,
+        ok: true,
+        status: 200,
+        searchReadyReason: "bm25 index not built (cold boot; first search scans the corpus)",
+      },
+      identity,
+    );
+    expect(cold.ok).toBe(true);
+    expect(cold.searchReady).toBe(false);
+    expect(cold.searchReadyReason).toMatch(/bm25 index not built/);
+  });
+
+  test("routes-down body carries ok:false so a status-only reader is not the only honest signal", () => {
+    const body = buildPublicHealthBody(
+      {
+        searchReady: false,
+        ok: false,
+        status: 503,
+        searchReadyReason: "search routes not mounted (SemanticSearch)",
+      },
+      { version: "dev", buildCommit: null },
+    );
+    expect(body.ok).toBe(false);
+    expect(body.searchReady).toBe(false);
+    expect(body.buildCommit).toBeNull();
+  });
+});

--- a/test/unit/search-readiness.test.ts
+++ b/test/unit/search-readiness.test.ts
@@ -127,6 +127,23 @@ describe("resolveSearchReadiness (flair#1326)", () => {
     expect(r.status).toBe(200);
   });
 
+  test("FLAIR_BM25_INDEX off: empty is the kill-switch steady state, not cold lag", () => {
+    // ensureReady never builds when the index is killed, so status stays
+    // empty for the process lifetime while hybrid still serves the legacy
+    // per-query scan. searchReady must not stay false forever.
+    const r = resolveSearchReadiness({
+      resources: mounted,
+      memoryTable,
+      bm25: { state: "empty" },
+      hybridEnabled: true,
+      bm25IndexEnabled: false,
+    });
+    expect(r.searchReady).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.status).toBe(200);
+    expect(r.searchReadyReason).toBeUndefined();
+  });
+
   test("BM25 disabled (legacy per-query scan) is still serving, so searchReady stays true", () => {
     const r = resolveSearchReadiness({
       resources: mounted,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1326.

`/Health` answered `{ok: true}` as soon as the Health resource loaded. After restart that is a green light that lies: Harper can already be 200 while `/Memory` and `/SemanticSearch` are still catch-all 404s, and the hybrid BM25 index is empty until the first search scans the corpus (that lag grows with store size). Anything that gates traffic on `/health` then sends recall to a node that is not recall-ready.

## What changed

`/Health` now always includes `searchReady`. Two layers, on purpose:

- **Search cannot be served** (routes not mounted, or the Memory table does not answer) → HTTP 503 and `ok: false`. A status-only probe must not get a green light.
- **Process is live but recall is still cold** (BM25 index `empty` / `building`) → HTTP 200, `ok: true`, `searchReady: false`, and `searchReadyReason` names the lag. We do not 503 on a cold index: the index builds on the first search, and a health check must not trigger that scan. 503-until-warm would deadlock.

`/HealthDetail` carries the same fields (and a warning) so `flair status` can see the lag. Decision lives in Harper-free `resources/search-readiness.ts` so the shipped function is unit-tested without a 66k-row store.

## Out of scope

This PR does not mix #1032, #1012, #1004, #1147, #1122, #1038, #1371, #998, #1248, #1395, or #1397. It does not warm the index from `/Health`, and it does not change the canary / filtered-ANN starvation work that was split off this issue.

Issue is assigned (heskew).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4614319-ed52-46fb-8239-54a25fb4518f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4614319-ed52-46fb-8239-54a25fb4518f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

