### PR TITLE
Specify retrieval order on equal fused ranks

### DIFF
--- a/.changelog/unreleased/fixed-1412-retrieval-tie-order.md
+++ b/.changelog/unreleased/fixed-1412-retrieval-tie-order.md
@@ -1,0 +1,7 @@
+- **Tied retrieval results now have a specified order** (flair#1412).
+  When fused ranks are equal, the newer `createdAt` wins and `id`
+  ascending is the total-order backstop, so the same query against the
+  same store returns the same order after a restart. A missing
+  `createdAt` sorts as oldest (never NaN). Recency within a tie is
+  best-effort across federated writers — clock skew cannot reintroduce
+  nondeterminism.

--- a/packages/flair-bench/src/cosine.ts
+++ b/packages/flair-bench/src/cosine.ts
@@ -9,6 +9,8 @@
  * rather than approximate ones.
  */
 
+import { compareKey } from "./sort-comparators.js";
+
 export function cosineSimilarity(a: readonly number[], b: readonly number[]): number {
   if (a.length !== b.length) {
     throw new Error(`cosineSimilarity: dimension mismatch (${a.length} vs ${b.length})`);
@@ -29,15 +31,15 @@ export function cosineSimilarity(a: readonly number[], b: readonly number[]): nu
 
 /**
  * 0-based rank of `targetIndex` within `corpusVectors` when sorted by
- * descending cosine similarity to `query`. Ties are broken by corpus
- * insertion order (stable sort — Array.prototype.sort is guaranteed stable
- * since ES2019/V8 since Node 11), the simplest documented tie-break
- * available without reverse-engineering Harper's own HNSW/BM25-RRF
- * tie-break internals. See README's "exact-vs-HNSW caveat" for what this
- * does and doesn't guarantee to reproduce.
+ * descending cosine similarity to `query`. Ties break on corpus `.index`
+ * ascending (the total-order tail — not `.id`; this ranking never has one).
+ * Input order of the scored array must not leak: the same corpus in two
+ * permutations of equal-score rows ranks identically (flair#1412).
+ * See README's "exact-vs-HNSW caveat" for what this does and doesn't
+ * guarantee to reproduce of Harper's HNSW.
  */
 export function rankOf(query: readonly number[], corpusVectors: readonly (readonly number[])[], targetIndex: number): number {
   const scored = corpusVectors.map((v, index) => ({ index, score: cosineSimilarity(query, v) }));
-  scored.sort((x, y) => y.score - x.score);
+  scored.sort((x, y) => (y.score - x.score) || compareKey(x.index, y.index));
   return scored.findIndex((s) => s.index === targetIndex);
 }

--- a/packages/flair-bench/src/sort-comparators.ts
+++ b/packages/flair-bench/src/sort-comparators.ts
@@ -1,0 +1,12 @@
+/**
+ * Generic total-order tail (flair#1412). Same helper as
+ * `resources/sort-comparators.ts` — copied so this package stays
+ * standalone (no flair install, no Harper). Cosine ranking keys on
+ * corpus `.index`, not `.id`; force-fitting `byNumberDescThenId` here
+ * would be the over-abstraction the #1412 spec names as the failure mode.
+ *
+ * Locale-independent code-unit / numeric comparison — not localeCompare.
+ */
+export function compareKey<T extends string | number>(a: T, b: T): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/packages/flair-bench/test/cosine.test.ts
+++ b/packages/flair-bench/test/cosine.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { cosineSimilarity, rankOf } from "../src/cosine.js";
+import { compareKey } from "../src/sort-comparators.js";
 
 describe("cosineSimilarity", () => {
   test("identical vectors -> 1", () => {
@@ -46,5 +47,28 @@ describe("rankOf", () => {
 
   test("middle match ranks in between", () => {
     expect(rankOf(query, corpus, 1)).toBe(1);
+  });
+
+  test("tied cosine scores break on corpus index, not scored-array input order", () => {
+    // Same comparator rankOf uses. Two identical vectors (score tie) plus a
+    // worse one — permute the scored rows and the ranking must not move.
+    const queryV = [1, 0];
+    const tied = [1, 0];
+    const worse = [0, 1];
+    const corpus = [tied, tied, worse];
+    expect(rankOf(queryV, corpus, 0)).toBe(0);
+    expect(rankOf(queryV, corpus, 1)).toBe(1);
+    expect(rankOf(queryV, corpus, 2)).toBe(2);
+
+    const scored = corpus.map((v, index) => ({ index, score: cosineSimilarity(queryV, v) }));
+    expect(new Set(scored.filter((s) => s.index !== 2).map((s) => s.score)).size).toBe(1);
+    const cmp = (
+      a: { index: number; score: number },
+      b: { index: number; score: number },
+    ) => (b.score - a.score) || compareKey(a.index, b.index);
+    const forward = [...scored].sort(cmp).map((s) => s.index);
+    const reversed = [...scored].reverse().sort(cmp).map((s) => s.index);
+    expect(forward).toEqual([0, 1, 2]);
+    expect(reversed).toEqual(forward);
   });
 });

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -60,6 +60,7 @@ import { compositeScore } from "./scoring.js";
 import { buildBM25, fuseRrfNormalized, SEM_LIMIT } from "./bm25.js";
 import { isAllowedBm25Candidate, type Condition } from "./bm25-filter.js";
 import { indexedBm25Ids } from "./bm25-index-service.js";
+import { byRecencyThenId } from "./sort-comparators.js";
 
 // Convert HNSW cosine distance (1 - similarity) to similarity score.
 function distanceToSimilarity(distance: number): number {
@@ -576,7 +577,14 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
   // retrieval lives in the fused ORDER (a BM25 rank-1 rescue outranks weak
   // semantic hits), while `_score` carries the honest absolute evidence for
   // each result — the two can disagree, and that is correct.
-  filteredResults.sort((a: any, b: any) => b._rank - a._rank);
+  //
+  // Ties at this sort are cross-leg RRF identities (flair#1412): no
+  // within-leg tie-break can prevent `1/(k+3)+1/(k+5) === 1/(k+5)+1/(k+3)`.
+  // Break them by createdAt DESC (null → oldest, never NaN) then id ASC.
+  // Determinism is the id ASC total order. createdAt is best-effort recency
+  // within an exact `_rank` tie — federated writer clocks can skew, and
+  // that cannot reintroduce nondeterminism (see byRecencyThenId).
+  filteredResults.sort((a: any, b: any) => (b._rank - a._rank) || byRecencyThenId(a, b));
   for (const r of filteredResults) delete r._rank;
   return filteredResults;
 }

--- a/resources/sort-comparators.ts
+++ b/resources/sort-comparators.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic sort comparators (flair#1412).
+ *
+ * Retrieval and selection sorts used to key on one number (score, rank,
+ * priority) and then inherit `Array.prototype.sort`'s input order on ties.
+ * That input order is Harper scan order, which is free to change across
+ * restarts. The family below makes the tie-break the default thing to
+ * reach for: each helper has its own primary key, and they share the
+ * `compareKey` tail — not one comparator forced onto every site.
+ *
+ * Do not collapse this into a single `byScoreThenId`. cosine.ts keys on
+ * corpus `.index`; MemoryBootstrap (flair#1409, not this PR) keys on the
+ * soul `key`. The shared part is the tail.
+ *
+ * Locale-independent: `compareKey` is code-unit / numeric `<`/`>`, never
+ * `localeCompare`. ISO-8601 UTC strings compare chronologically that way.
+ */
+
+/** Total-order tail. Works for ids, corpus indexes, soul keys. */
+export function compareKey<T extends string | number>(a: T, b: T): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Score / rank descending, then `id` ascending. */
+export function byNumberDescThenId<T extends { id: string }>(
+  getNumber: (row: T) => number,
+): (a: T, b: T) => number {
+  return (a, b) => (getNumber(b) - getNumber(a)) || compareKey(a.id, b.id);
+}
+
+/**
+ * `createdAt` DESC (null → oldest, never NaN) then `id` ASC.
+ *
+ * Determinism comes from `id` ASC — ids are unique, so this is a total
+ * order no matter what `createdAt` does. Do not date-arithmetic a
+ * possibly-null field: `new Date(null).getTime()` is 0, but subtracting
+ * NaN (unparseable / missing-after-coercion) is undefined behaviour for
+ * `Array.prototype.sort`. Empty-string fallback keeps the comparison in
+ * string space; an empty value is less than any ISO-8601 UTC timestamp,
+ * so it sorts last under DESC.
+ *
+ * Clock-skew caveat: `createdAt` is writer-stamped. Across federated
+ * writers this is best-effort recency within an exact `_rank` tie, not a
+ * correctness claim. Skew can misorder rows the ranker already called
+ * equivalent; it cannot reintroduce nondeterminism, because `id` ASC
+ * still resolves every remaining tie.
+ */
+export function byRecencyThenId<T extends { id: string; createdAt?: string | null }>(
+  a: T,
+  b: T,
+): number {
+  return compareKey(b.createdAt ?? "", a.createdAt ?? "") || compareKey(a.id, b.id);
+}

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -40,7 +40,7 @@
  *     reproduce Harper's own shape exactly, or a rescued record's response
  *     bytes would differ from a scanned one's.
  *
- * VEHICLE for premise 1: `GET /Memory/?` (Memory.search → Harper Table.search)
+ * VEHICLE for premise 1: `GET /Memory/` (Memory.search → Harper Table.search)
  * for the scope OR-group scan, and ops `search_by_value` for the tags/subject
  * index seek. Do NOT use SemanticSearch — after flair#1412 that path is
  * `createdAt DESC, id ASC` on an all-equal `_rank` and no longer leaks scan

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -40,10 +40,12 @@
  *     reproduce Harper's own shape exactly, or a rescued record's response
  *     bytes would differ from a scanned one's.
  *
- * VEHICLE for premise 1: a `SemanticSearch` with neither `q` nor an embedding
- * returns `allowedById.values()` — a Map built in corpus-scan order — and then
- * stable-sorts on an all-equal `_rank`. So the response order IS the scan
- * order.
+ * VEHICLE for premise 1: `GET /Memory` (Memory.search → Harper Table.search)
+ * with the same read-scope OR-group the listing path uses. Do NOT use
+ * SemanticSearch for this measurement — after flair#1412 the final retrieval
+ * sort is `createdAt DESC, id ASC` on an all-equal `_rank`, so SemanticSearch
+ * no longer leaks scan order. The premise is about Harper's planner, not
+ * about retrieval ranking.
  */
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import nacl from "tweetnacl";
@@ -106,6 +108,19 @@ async function search(body: Record<string, any>): Promise<any> {
 
 const ids = (r: any) => (r.results ?? []).map((x: any) => x.id);
 
+async function memoryIds(query = ""): Promise<string[]> {
+  // Premise 1 vehicle: Memory.search, not SemanticSearch (flair#1412).
+  const path = query ? `/Memory?${query}` : "/Memory";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    headers: { Authorization: ed25519Header(agent, "GET", path) },
+  });
+  const text = await res.text();
+  expect(res.status, `GET ${path} → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+  const body = JSON.parse(text);
+  const rows = Array.isArray(body) ? body : (body.results ?? body.items ?? []);
+  return rows.map((x: any) => x.id).filter((id: string) => INSERT_ORDER.includes(id));
+}
+
 // File-scope lifecycle: both describes below share ONE instance. A
 // describe-scoped afterAll would stop Harper before the second block ran.
 beforeAll(async () => {
@@ -133,7 +148,7 @@ afterAll(async () => { if (harper) await stopHarper(harper); });
 
 describe("flair#1357 — real-Harper premises of the persistent BM25 index", () => {
   test("PREMISE 1: the multi-agent scope scan is NOT primary-key order — own rows lead", async () => {
-    const observed = ids(await search({}));
+    const observed = await memoryIds();
     const own = INSERT_ORDER.filter((_, i) => i % 2 === 0).sort();
     const other = INSERT_ORDER.filter((_, i) => i % 2 === 1).sort();
     // Own rows first (primary-key order within the group), then the rest.
@@ -147,8 +162,8 @@ describe("flair#1357 — real-Harper premises of the persistent BM25 index", () 
   test("PREMISE 1: a tags/subject-filtered scan of the SAME rows comes back in a DIFFERENT order", async () => {
     // Same store, same rows, different plan, different iteration order — the
     // reason a fixed tie-break cannot be correct for every query.
-    expect(ids(await search({ tag: "shared-tag" }))).toEqual(LEX_ORDER);
-    expect(ids(await search({ subject: "shared-subject" }))).toEqual(LEX_ORDER);
+    expect(await memoryIds("tags=shared-tag")).toEqual(LEX_ORDER);
+    expect(await memoryIds("subject=shared-subject")).toEqual(LEX_ORDER);
   }, 60_000);
 
 

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -40,12 +40,11 @@
  *     reproduce Harper's own shape exactly, or a rescued record's response
  *     bytes would differ from a scanned one's.
  *
- * VEHICLE for premise 1: `GET /Memory` (Memory.search → Harper Table.search)
- * with the same read-scope OR-group the listing path uses. Do NOT use
- * SemanticSearch for this measurement — after flair#1412 the final retrieval
- * sort is `createdAt DESC, id ASC` on an all-equal `_rank`, so SemanticSearch
- * no longer leaks scan order. The premise is about Harper's planner, not
- * about retrieval ranking.
+ * VEHICLE for premise 1: `GET /Memory/?` (Memory.search → Harper Table.search)
+ * for the scope OR-group scan, and ops `search_by_value` for the tags/subject
+ * index seek. Do NOT use SemanticSearch — after flair#1412 that path is
+ * `createdAt DESC, id ASC` on an all-equal `_rank` and no longer leaks scan
+ * order. `GET /Memory` (no slash) is the collection describe, not a search.
  */
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import nacl from "tweetnacl";
@@ -116,9 +115,11 @@ function rowIds(body: any): string[] {
 async function memoryIds(): Promise<string[]> {
   // Premise 1 unfiltered vehicle: Memory.search (scope OR-group), not
   // SemanticSearch — after flair#1412 that path is createdAt/id ordered.
-  // GET /Memory (no slash/query) is the collection DESCRIBE, not a search.
-  // GET /Memory/? is the collection-search form (auth-middleware e2e).
-  const path = "/Memory/?";
+  // GET /Memory (no slash) is the collection DESCRIBE, not a search.
+  // GET /Memory/ is the collection-search form. Sign pathname only —
+  // `url.pathname + url.search` for `/Memory/?` is `/Memory/` (empty
+  // search), so signing `/Memory/?` 401s as invalid_signature.
+  const path = "/Memory/";
   const res = await fetch(`${harper.httpURL}${path}`, {
     headers: { Authorization: ed25519Header(agent, "GET", path) },
   });

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -108,17 +108,44 @@ async function search(body: Record<string, any>): Promise<any> {
 
 const ids = (r: any) => (r.results ?? []).map((x: any) => x.id);
 
-async function memoryIds(query = ""): Promise<string[]> {
-  // Premise 1 vehicle: Memory.search, not SemanticSearch (flair#1412).
-  const path = query ? `/Memory?${query}` : "/Memory";
+function rowIds(body: any): string[] {
+  const rows = Array.isArray(body) ? body : (body?.results ?? body?.items ?? []);
+  return rows.map((x: any) => x.id).filter((id: string) => INSERT_ORDER.includes(id));
+}
+
+async function memoryIds(): Promise<string[]> {
+  // Premise 1 unfiltered vehicle: Memory.search (scope OR-group), not
+  // SemanticSearch — after flair#1412 that path is createdAt/id ordered.
+  // GET /Memory (no slash/query) is the collection DESCRIBE, not a search.
+  // GET /Memory/? is the collection-search form (auth-middleware e2e).
+  const path = "/Memory/?";
   const res = await fetch(`${harper.httpURL}${path}`, {
     headers: { Authorization: ed25519Header(agent, "GET", path) },
   });
   const text = await res.text();
   expect(res.status, `GET ${path} → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
-  const body = JSON.parse(text);
-  const rows = Array.isArray(body) ? body : (body.results ?? body.items ?? []);
-  return rows.map((x: any) => x.id).filter((id: string) => INSERT_ORDER.includes(id));
+  const ids = rowIds(JSON.parse(text));
+  expect(ids.length, `GET ${path} returned no fixture rows: ${text.slice(0, 200)}`).toBeGreaterThan(0);
+  return ids;
+}
+
+async function indexSeekIds(attribute: string, value: string): Promise<string[]> {
+  // Tags/subject index seek — the plan SemanticSearch's extra equals
+  // condition used to select. REST `?tags=` does not switch the planner
+  // (CI: same own-then-other order as the scope scan).
+  const res = await adminOp(harper, {
+    operation: "search_by_value",
+    database: "flair",
+    table: "Memory",
+    search_attribute: attribute,
+    search_value: value,
+    get_attributes: ["id"],
+  });
+  const text = await res.text();
+  expect(res.status, `search_by_value ${attribute}=${value} → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+  const ids = rowIds(JSON.parse(text));
+  expect(ids.length, `search_by_value ${attribute} returned no fixture rows`).toBeGreaterThan(0);
+  return ids;
 }
 
 // File-scope lifecycle: both describes below share ONE instance. A
@@ -162,8 +189,8 @@ describe("flair#1357 — real-Harper premises of the persistent BM25 index", () 
   test("PREMISE 1: a tags/subject-filtered scan of the SAME rows comes back in a DIFFERENT order", async () => {
     // Same store, same rows, different plan, different iteration order — the
     // reason a fixed tie-break cannot be correct for every query.
-    expect(await memoryIds("tags=shared-tag")).toEqual(LEX_ORDER);
-    expect(await memoryIds("subject=shared-subject")).toEqual(LEX_ORDER);
+    expect(await indexSeekIds("tags", "shared-tag")).toEqual(LEX_ORDER);
+    expect(await indexSeekIds("subject", "shared-subject")).toEqual(LEX_ORDER);
   }, 60_000);
 
 

--- a/test/unit/sort-comparators-1412.test.ts
+++ b/test/unit/sort-comparators-1412.test.ts
@@ -73,9 +73,10 @@ describe("byRecencyThenId — createdAt DESC (null→oldest) then id ASC", () =>
   });
 
   test("never returns NaN — including null / missing createdAt", () => {
-    const a = { id: "a", createdAt: null };
-    const b = { id: "b" };
-    const c = { id: "c", createdAt: "2024-01-01T00:00:00.000Z" };
+    type Row = { id: string; createdAt?: string | null };
+    const a: Row = { id: "a", createdAt: null };
+    const b: Row = { id: "b" };
+    const c: Row = { id: "c", createdAt: "2024-01-01T00:00:00.000Z" };
     expect(Number.isNaN(byRecencyThenId(a, b))).toBe(false);
     expect(Number.isNaN(byRecencyThenId(a, c))).toBe(false);
     expect(Number.isNaN(byRecencyThenId(b, c))).toBe(false);

--- a/test/unit/sort-comparators-1412.test.ts
+++ b/test/unit/sort-comparators-1412.test.ts
@@ -1,0 +1,106 @@
+/**
+ * sort-comparators-1412.test.ts — input-order independence for the #1412
+ * comparator family.
+ *
+ * The defect: a stable sort on one key keeps input order on ties, and that
+ * input order is Harper scan order (free to change across restarts). The
+ * powered check is exactly that property: the same result set, two input
+ * orders, identical output. A restart-based test would catch the same
+ * thing indirectly; this one names it.
+ *
+ * One describe per comparator. The byRecencyThenId fixture has real ties
+ * (equal `_rank`, differing `createdAt` / `id`) and asserts newer
+ * `createdAt` wins. Null `createdAt` is oldest, never NaN.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  compareKey,
+  byNumberDescThenId,
+  byRecencyThenId,
+} from "../../resources/sort-comparators.ts";
+
+function ids<T extends { id: string }>(rows: T[]): string[] {
+  return rows.map((r) => r.id);
+}
+
+function sortCopy<T>(rows: T[], cmp: (a: T, b: T) => number): T[] {
+  return [...rows].sort(cmp);
+}
+
+describe("byNumberDescThenId — score/rank descending, then id ASC", () => {
+  const byScore = byNumberDescThenId<{ id: string; score: number }>((r) => r.score);
+  // Real ties: equal score, differing id. Plus one strictly-higher score
+  // so the primary key still dominates.
+  const fixture = [
+    { id: "zzz", score: 0.5 },
+    { id: "aaa", score: 0.5 },
+    { id: "mmm", score: 0.9 },
+    { id: "nnn", score: 0.5 },
+  ];
+
+  test("the same set in two input orders ranks identically, high score first, ties by id ASC", () => {
+    const expected = ["mmm", "aaa", "nnn", "zzz"];
+    const forward = sortCopy(fixture, byScore);
+    const reversed = sortCopy([...fixture].reverse(), byScore);
+    expect(ids(forward)).toEqual(expected);
+    expect(ids(reversed)).toEqual(expected);
+  });
+});
+
+describe("byRecencyThenId — createdAt DESC (null→oldest) then id ASC", () => {
+  // Equal `_rank` (the line-579 primary key), differing createdAt / id.
+  // This is the fixture the #1412 spec names: a test that seeded unequal
+  // `_rank` would pass vacuously on the recency tail.
+  const fixture = [
+    { id: "old-z", _rank: 1, createdAt: "2024-01-01T00:00:00.000Z" },
+    { id: "new-m", _rank: 1, createdAt: "2024-06-01T00:00:00.000Z" },
+    { id: "old-a", _rank: 1, createdAt: "2024-01-01T00:00:00.000Z" },
+    { id: "null-b", _rank: 1, createdAt: null },
+    { id: "missing-c", _rank: 1 },
+  ];
+  const retrievalCmp = (
+    a: (typeof fixture)[number],
+    b: (typeof fixture)[number],
+  ) => (b._rank - a._rank) || byRecencyThenId(a, b);
+
+  test("two input orders are identical, newer createdAt wins, null is oldest, id ASC on a createdAt tie", () => {
+    const expected = ["new-m", "old-a", "old-z", "missing-c", "null-b"];
+    const forward = sortCopy(fixture, retrievalCmp);
+    const reversed = sortCopy([...fixture].reverse(), retrievalCmp);
+    expect(ids(forward)).toEqual(expected);
+    expect(ids(reversed)).toEqual(ids(forward));
+    expect(forward[0].createdAt).toBe("2024-06-01T00:00:00.000Z");
+  });
+
+  test("never returns NaN — including null / missing createdAt", () => {
+    const a = { id: "a", createdAt: null };
+    const b = { id: "b" };
+    const c = { id: "c", createdAt: "2024-01-01T00:00:00.000Z" };
+    expect(Number.isNaN(byRecencyThenId(a, b))).toBe(false);
+    expect(Number.isNaN(byRecencyThenId(a, c))).toBe(false);
+    expect(Number.isNaN(byRecencyThenId(b, c))).toBe(false);
+  });
+});
+
+describe("compareKey — generic tail (unusual keys still get the backstop)", () => {
+  // Cosine's shape: score DESC, then corpus `.index` ASC — not `.id`.
+  const byScoreThenIndex = (
+    a: { index: number; score: number },
+    b: { index: number; score: number },
+  ) => (b.score - a.score) || compareKey(a.index, b.index);
+
+  const fixture = [
+    { index: 4, score: 0.8 },
+    { index: 1, score: 0.8 },
+    { index: 3, score: 0.9 },
+    { index: 2, score: 0.8 },
+  ];
+
+  test("the same scored rows in two input orders rank identically; ties break on index ASC", () => {
+    const expected = [3, 1, 2, 4];
+    const forward = sortCopy(fixture, byScoreThenIndex).map((r) => r.index);
+    const reversed = sortCopy([...fixture].reverse(), byScoreThenIndex).map((r) => r.index);
+    expect(forward).toEqual(expected);
+    expect(reversed).toEqual(expected);
+  });
+});

--- a/test/unit/sort-determinism-guard.test.ts
+++ b/test/unit/sort-determinism-guard.test.ts
@@ -1,0 +1,195 @@
+/**
+ * sort-determinism-guard.test.ts — AST guard for flair#1412.
+ *
+ * Grep cannot tell a real `.sort` from a comment mentioning one, and cannot
+ * see comparator shape. This walks the TypeScript AST and flags a `.sort()`
+ * whose comparator is a single key with no `||` tie-break tail.
+ *
+ * Scoped ONLY to the paths this PR fixes. Shipping it repo-wide would fail
+ * ~13 pre-existing display/admin sorts and bury the site that matters.
+ * Widen the list as those follow-ups land.
+ *
+ * Opt-out (exact marker, not any comment): `// deterministic: key is unique`
+ */
+import { describe, test, expect } from "bun:test";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+/** Paths this PR fixed. Do not widen here — that is the follow-up sweep. */
+export const SCOPED_PATHS = [
+  "resources/semantic-retrieval-core.ts",
+  "packages/flair-bench/src/cosine.ts",
+] as const;
+
+const OPT_OUT = "deterministic: key is unique";
+
+export type BareSortHit = { line: number; excerpt: string };
+
+function unwrap(expr: ts.Expression): ts.Expression {
+  let e = expr;
+  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isSatisfiesExpression(e)) {
+    e = e.expression;
+  }
+  return e;
+}
+
+function comparatorBody(fn: ts.ArrowFunction | ts.FunctionExpression): ts.Expression | undefined {
+  if (!ts.isBlock(fn.body)) return fn.body;
+  const returns = fn.body.statements.filter(ts.isReturnStatement);
+  if (returns.length !== 1 || !returns[0].expression) return undefined;
+  return returns[0].expression;
+}
+
+function isLocaleCompareCall(expr: ts.Expression): boolean {
+  const e = unwrap(expr);
+  return ts.isCallExpression(e)
+    && ts.isPropertyAccessExpression(e.expression)
+    && e.expression.name.text === "localeCompare";
+}
+
+function isSingleKeyComparator(expr: ts.Expression): boolean {
+  const e = unwrap(expr);
+  if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
+    return false;
+  }
+  if (ts.isConditionalExpression(e)) {
+    // `a.id < b.id ? -1 : a.id > b.id ? 1 : 0` is a single-key id compare.
+    // Treat as single-key unless a branch itself is a `||` chain.
+    return isSingleKeyComparator(e.whenTrue) && isSingleKeyComparator(e.whenFalse)
+      && isSingleKeyComparator(e.condition);
+  }
+  if (isLocaleCompareCall(e)) return true;
+  if (ts.isBinaryExpression(e)) {
+    const op = e.operatorToken.kind;
+    return op === ts.SyntaxKind.MinusToken
+      || op === ts.SyntaxKind.LessThanToken
+      || op === ts.SyntaxKind.GreaterThanToken
+      || op === ts.SyntaxKind.LessThanEqualsToken
+      || op === ts.SyntaxKind.GreaterThanEqualsToken;
+  }
+  return false;
+}
+
+function commentHasOptOut(text: string): boolean {
+  return text.includes(OPT_OUT);
+}
+
+function nodeHasOptOut(sf: ts.SourceFile, node: ts.Node): boolean {
+  const full = sf.getFullText();
+  const ranges = [
+    ...(ts.getLeadingCommentRanges(full, node.getFullStart()) ?? []),
+    ...(ts.getTrailingCommentRanges(full, node.getEnd()) ?? []),
+  ];
+  // The statement containing the call (so a line-above comment counts).
+  let stmt: ts.Node = node;
+  while (stmt.parent && !ts.isSourceFile(stmt.parent) && !ts.isBlock(stmt.parent) && !ts.isSourceFile(stmt)) {
+    if (ts.isExpressionStatement(stmt) || ts.isVariableStatement(stmt) || ts.isReturnStatement(stmt)) break;
+    stmt = stmt.parent;
+  }
+  ranges.push(...(ts.getLeadingCommentRanges(full, stmt.getFullStart()) ?? []));
+  if (ranges.some((r) => commentHasOptOut(full.slice(r.pos, r.end)))) return true;
+  // Same-line trailing comment after the statement.
+  const line = sf.getLineAndCharacterOfPosition(node.getStart(sf)).line;
+  const lineStart = sf.getPositionOfLineAndCharacter(line, 0);
+  const nextLineStart = line + 1 < sf.getLineStarts().length
+    ? sf.getLineStarts()[line + 1]!
+    : full.length;
+  return commentHasOptOut(full.slice(lineStart, nextLineStart));
+}
+
+export function findBareSingleKeySorts(filePath: string, source: string): BareSortHit[] {
+  const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const hits: BareSortHit[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node)
+      && ts.isPropertyAccessExpression(node.expression)
+      && node.expression.name.text === "sort"
+      && node.arguments.length >= 1) {
+      const arg = node.arguments[0]!;
+      if ((ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
+        const body = comparatorBody(arg);
+        if (body && isSingleKeyComparator(body) && !nodeHasOptOut(sf, node)) {
+          const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+          hits.push({
+            line: line + 1,
+            excerpt: source.slice(node.getStart(sf), Math.min(node.getEnd(), node.getStart(sf) + 80)).replace(/\s+/g, " "),
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return hits;
+}
+
+function scanRepoFile(rel: string): BareSortHit[] {
+  const abs = join(REPO_ROOT, rel);
+  return findBareSingleKeySorts(rel, readFileSync(abs, "utf8"));
+}
+
+describe("sort-determinism guard scope (flair#1412)", () => {
+  test("is scoped to the two paths this PR fixes — not repo-wide", () => {
+    expect([...SCOPED_PATHS].sort()).toEqual([
+      "packages/flair-bench/src/cosine.ts",
+      "resources/semantic-retrieval-core.ts",
+    ]);
+    for (const p of SCOPED_PATHS) {
+      expect(existsSync(join(REPO_ROOT, p))).toBe(true);
+    }
+  });
+
+  test("the scoped paths have no bare single-key sort", () => {
+    const hits = SCOPED_PATHS.flatMap((p) => scanRepoFile(p).map((h) => `${p}:${h.line} ${h.excerpt}`));
+    expect(hits).toEqual([]);
+  });
+});
+
+describe("sort-determinism guard detector", () => {
+  test("FAILS on a newly added bare single-key sort", () => {
+    const src = `
+      const xs = [{ n: 1 }, { n: 2 }];
+      xs.sort((a, b) => b.n - a.n);
+    `;
+    const hits = findBareSingleKeySorts("scratch.ts", src);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.excerpt).toContain("b.n - a.n");
+  });
+
+  test("FAILS on a bare localeCompare", () => {
+    const src = `rows.sort((a, b) => a.ts.localeCompare(b.ts));`;
+    expect(findBareSingleKeySorts("scratch.ts", src).length).toBe(1);
+  });
+
+  test("does not flag a comment that merely mentions .sort", () => {
+    const src = `
+      // rows.sort((a, b) => b.score - a.score)
+      const x = 1;
+    `;
+    expect(findBareSingleKeySorts("scratch.ts", src)).toEqual([]);
+  });
+
+  test("passes when a || tie-break tail is present", () => {
+    const src = `rows.sort((a, b) => (b._rank - a._rank) || byRecencyThenId(a, b));`;
+    expect(findBareSingleKeySorts("scratch.ts", src)).toEqual([]);
+  });
+
+  test("opt-out marker // deterministic: key is unique suppresses the flag", () => {
+    const src = `
+      // deterministic: key is unique
+      names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);
+    `;
+    expect(findBareSingleKeySorts("scratch.ts", src)).toEqual([]);
+  });
+
+  test("a generic comment is not an opt-out", () => {
+    const src = `
+      // this sort is fine, trust me
+      xs.sort((a, b) => b.n - a.n);
+    `;
+    expect(findBareSingleKeySorts("scratch.ts", src).length).toBe(1);
+  });
+});

--- a/test/unit/sort-determinism-guard.test.ts
+++ b/test/unit/sort-determinism-guard.test.ts
@@ -50,6 +50,15 @@ function isLocaleCompareCall(expr: ts.Expression): boolean {
     && e.expression.name.text === "localeCompare";
 }
 
+/** `-1` / `0` / `1` — the leaves of `a < b ? -1 : a > b ? 1 : 0`. */
+function isComparatorConstant(expr: ts.Expression): boolean {
+  const e = unwrap(expr);
+  if (ts.isNumericLiteral(e)) return true;
+  return ts.isPrefixUnaryExpression(e)
+    && (e.operator === ts.SyntaxKind.MinusToken || e.operator === ts.SyntaxKind.PlusToken)
+    && ts.isNumericLiteral(e.operand);
+}
+
 function isSingleKeyComparator(expr: ts.Expression): boolean {
   const e = unwrap(expr);
   if (ts.isBinaryExpression(e) && e.operatorToken.kind === ts.SyntaxKind.BarBarToken) {
@@ -57,9 +66,10 @@ function isSingleKeyComparator(expr: ts.Expression): boolean {
   }
   if (ts.isConditionalExpression(e)) {
     // `a.id < b.id ? -1 : a.id > b.id ? 1 : 0` is a single-key id compare.
-    // Treat as single-key unless a branch itself is a `||` chain.
-    return isSingleKeyComparator(e.whenTrue) && isSingleKeyComparator(e.whenFalse)
-      && isSingleKeyComparator(e.condition);
+    // Constants are valid LEAVES (the ±1/0 the comparator returns), not a
+    // second key. A branch that itself has `||` is not single-key.
+    const leaf = (x: ts.Expression) => isComparatorConstant(x) || isSingleKeyComparator(x);
+    return leaf(e.whenTrue) && leaf(e.whenFalse) && isSingleKeyComparator(e.condition);
   }
   if (isLocaleCompareCall(e)) return true;
   if (ts.isBinaryExpression(e)) {
@@ -175,6 +185,16 @@ describe("sort-determinism guard detector", () => {
   test("passes when a || tie-break tail is present", () => {
     const src = `rows.sort((a, b) => (b._rank - a._rank) || byRecencyThenId(a, b));`;
     expect(findBareSingleKeySorts("scratch.ts", src)).toEqual([]);
+  });
+
+  test("FAILS on the classic a<b ? -1 : a>b ? 1 : 0 ternary (no || tail)", () => {
+    // Constants are the comparator's return values, not a second key.
+    // If this were not flagged, the opt-out test below would pass with the
+    // marker removed and could not catch a broken opt-out path.
+    const src = `names.sort((a, b) => a.name < b.name ? -1 : a.name > b.name ? 1 : 0);`;
+    const hits = findBareSingleKeySorts("scratch.ts", src);
+    expect(hits.length).toBe(1);
+    expect(hits[0]!.excerpt).toContain("a.name < b.name");
   });
 
   test("opt-out marker // deterministic: key is unique suppresses the flag", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1412.

Tied fused `_rank` used to keep Harper scan order (`Array.prototype.sort` is stable; the comparator had no secondary key). Scan order is free to change across restarts — that is the ~1.4% `composite/4` wobble on the #1357 heavy lane, and it sits under every LongMemEval arm that restarts Harper per question.

Built from Flint's settled spec: https://github.com/tpsdev-ai/flair/issues/1412#issuecomment-5404568983

## What this PR does

1. **`resources/semantic-retrieval-core.ts` final sort** — `_rank` DESC, then `createdAt` DESC (null → oldest, never NaN), then `id` ASC. Determinism is the `id` ASC total order. Comment names the clock-skew caveat (best-effort recency within an exact `_rank` tie). No date-arithmetic on a possibly-null field. Code-unit comparison, not `localeCompare`.

2. **`packages/flair-bench/src/cosine.ts`** in the same change. Ties break on corpus `.index` ASC via the generic tail helper. Not forced onto a comparator that reads `.id`.

3. **Comparator family** (shared part is the `|| compareKey` tail, not the primary key):
   - `byNumberDescThenId` — score/rank descending, then id ASC
   - `byRecencyThenId` — createdAt DESC then id ASC (line 579 uses this)
   - `compareKey` — generic tail so an unusual key (cosine `.index`) still gets the backstop

   flair-bench carries its own copy of `compareKey` so the published package stays standalone.

4. **AST guard** (`test/unit/sort-determinism-guard.test.ts`) scoped only to the two paths this PR fixes. TypeScript compiler API, not grep. Opt-out: `// deterministic: key is unique`. Not shipped repo-wide (would fail ~13 pre-existing sites).

5. **Powered check** — same result set, two input orders, identical output. Fixture has real ties (equal `_rank`, differing `createdAt`/`id`). Newer `createdAt` wins. One describe per comparator.

## What this PR does not do

- `MemoryBootstrap.ts:550` / #1409 — separately
- `collision-lib`, `format.ts`, the nine createdAt display sorts
- Recency in RRF fusion
- #1358 instrument
- Ask B (subtract the #1357 parity control) — not in the settled spec. After this sort, a restart-coupled tie is no longer an equivalence defect to misattribute. A query that also diverges legacy-vs-legacy for another reason is still not an equivalence defect; that assertion change can follow if a new instability shows up.

`test/integration/bm25-index-scan-order-1357.test.ts` premise 1 no longer uses empty SemanticSearch as the scan-order vehicle: after this change that path is `createdAt`/`id` ordered, so it cannot leak Harper's planner. The measurement moved to `GET /Memory` (Memory.search → Table.search).

## Verify

Local: `bun test test/unit/sort-comparators-1412.test.ts test/unit/sort-determinism-guard.test.ts test/unit/bm25.test.ts` — 33 pass. `packages/flair-bench` cosine tests — 10 pass. Changelog fragments check — clean.

**Guard demonstrated red:** scratch commit `1412ebe` added `_scratch.sort((a, b) => b.n - a.n)` to `semantic-retrieval-core.ts`. Assertion `the scoped paths have no bare single-key sort` failed on `resources/semantic-retrieval-core.ts:590 _scratch.sort((a, b) => b.n - a.n)`. Scratch was reset; it is not in this PR.

**Red-on-main** (main `ab19beb` call sites + old comparators on the new fixtures):

| New test | On unmodified main |
|---|---|
| Guard: scoped paths have no bare single-key sort | **RED** — flags `:579` `b._rank - a._rank` and cosine `:41` `y.score - x.score` |
| `byRecencyThenId` two-order + newer wins | **RED** — old `_rank`-only sort: forward `old-z,new-m,…` vs reversed `missing-c,null-b,…`; first is `old-z` |
| `byRecencyThenId` never returns NaN | Does **not** go red — old sort subtracts `_rank` (a number). Locks the new null/`createdAt` NaN hazard. |
| `byNumberDescThenId` two-order | **RED** — old score-only sort: `mmm,zzz,aaa,nnn` vs `mmm,nnn,aaa,zzz` |
| `compareKey` / cosine tail two-order | **RED** — old score-only sort: `[3,4,1,2]` vs `[3,2,1,4]` |
| Guard detector fixtures + scope list | New; not red-on-main. Scope test is a **regression lock** so the guard cannot silently go repo-wide. |
| `rankOf` on `[tied,tied,worse]` index 0/1 | **PASS on main** — stable sort already keeps index order when the scored array is built in index order. Regression lock on already-shipped `rankOf`. The paired scored-array permutation (`forward === reversed`) is the part that goes red. |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5180e85-1c15-487e-b8cd-c37c3df7a3e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5180e85-1c15-487e-b8cd-c37c3df7a3e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

