### PR TITLE
docs(cursor-flair): stop telling users to install from a Marketplace we are not in

### DIFF
--- a/packages/cursor-flair/README.md
+++ b/packages/cursor-flair/README.md
@@ -1,12 +1,11 @@
-# @tpsdev-ai/cursor-flair
+# Flair for Cursor
 
-Cursor Marketplace plugin for [Flair](https://tps.dev/#flair) — self-hosted identity, memory, and soul for Cursor agents.
+Persistent memory, identity, and personality for your Cursor agents — stored in a Flair instance **you run**, not a vendor's cloud.
 
-This bundle is **not an npm runtime**. It wires Cursor to the stdio MCP server [`@tpsdev-ai/flair-mcp`](https://www.npmjs.com/package/@tpsdev-ai/flair-mcp) and ships skills plus one always-on rule. Memories live in **your** Flair/Harper instance (local or a URL you run). Nothing is stored in Cursor cloud.
+Install it and your agent remembers across sessions: decisions you made, preferences you stated, what a project is for. Ask *"what did we decide about X?"* three weeks later and get an answer.
 
-## Flair vs Cursor's built-in Memories
+This bundle is not an npm runtime. It wires Cursor to the stdio MCP server [`@tpsdev-ai/flair-mcp`](https://www.npmjs.com/package/@tpsdev-ai/flair-mcp) and ships the skills that drive it.
 
-Cursor ships a native **Memories** feature: persistent notes the agent saves as you work, stored in Cursor's cloud with your Cursor account, available in Cursor. Flair is a different shape — one memory you own: self-hosted, semantically searchable, and shared across every AI you use (Cursor, Grok Bot, Claude Code, your own agents) and with your team. The two coexist: keep Memories for quick scratch notes; Flair is the memory that follows you across tools.
 
 ## Prerequisites
 
@@ -26,9 +25,11 @@ flair status               # default HTTP origin: http://127.0.0.1:19926
 
 ## Install
 
-**Marketplace.** In Cursor, search **Flair** in the Marketplace, install, then **Plugins → Configure**.
+**Plugin directory.** Flair is listed at **[cursor.directory/plugins/flair](https://cursor.directory/plugins/flair)** — install it from there, then open **Plugins → Configure** in Cursor and set the variables below.
 
-**Local development.** Copy or symlink this directory to `~/.cursor/plugins/local/flair`, then Configure the same variables.
+**From this repository.** Copy or symlink `packages/cursor-flair` to `~/.cursor/plugins/local/flair`, then Configure the same variables. This is also the route for local development.
+
+> Flair is **not** currently in Cursor's built-in Marketplace, so searching there will not find it. Use one of the two paths above.
 
 ## Configure
 
@@ -40,6 +41,10 @@ Set these under **Plugins → Configure**. `FLAIR_CLIENT=cursor` is set for you 
 | `FLAIR_URL` | no | `http://127.0.0.1:19926` | Reachable Flair HTTP origin |
 
 Those are the only two fields in the plugin schema (`plugin.json`). `FLAIR_KEY_PATH` and `FLAIR_ADMIN_*` are documented here in the README only — they are **not** declared as plugin variables and **not** interpolated into `mcp.json`. Set them in the host env of the machine that runs `npx`. Keeping them out of `mcp.json` is deliberate: an unsubstituted `${FLAIR_KEY_PATH}` would be truthy and break key auto-resolve, and an unsubstituted admin password would send literal Basic auth.
+
+## Flair vs Cursor's built-in Memories
+
+Cursor ships a native **Memories** feature: persistent notes the agent saves as you work, stored in Cursor's cloud with your Cursor account, available in Cursor. Flair is a different shape — one memory you own: self-hosted, semantically searchable, and shared across every AI you use (Cursor, Grok Bot, Claude Code, your own agents) and with your team. The two coexist: keep Memories for quick scratch notes; Flair is the memory that follows you across tools.
 
 ## Grok Bot / Cursor cloud agents
 

--- a/packages/cursor-flair/README.md
+++ b/packages/cursor-flair/README.md
@@ -1,6 +1,6 @@
 # Flair for Cursor
 
-Persistent memory, identity, and personality for your Cursor agents — stored in a Flair instance **you run**, not a vendor's cloud.
+Persistent memory, identity, and personality for your Cursor agents — stored in a Flair instance **you control**: self-hosted by default, or Harper-hosted on Fabric. Never Cursor's cloud.
 
 Install it and your agent remembers across sessions: decisions you made, preferences you stated, what a project is for. Ask *"what did we decide about X?"* three weeks later and get an answer.
 
@@ -21,7 +21,7 @@ flair status               # default HTTP origin: http://127.0.0.1:19926
 
 **Grok Bot / Cursor cloud / another machine:** `127.0.0.1:19926` is not reachable. Start on Harper Fabric: **[docs/quickstart-fabric.md](../../docs/quickstart-fabric.md)**.
 
-`<id>` must match the `FLAIR_AGENT_ID` you configure in the plugin. Node.js **>= 22** is required on the machine that runs `npx` (the MCP server's engines field).
+`<id>` must match the `FLAIR_AGENT_ID` you configure in the plugin. Node.js **>= 22.18** is required on the machine that runs `npx` (the MCP server's engines field).
 
 ## Install
 
@@ -37,7 +37,7 @@ Set these under **Plugins → Configure**. `FLAIR_CLIENT=cursor` is set for you 
 
 | Variable | Required | Default | Notes |
 |---|---|---|---|
-| `FLAIR_AGENT_ID` | yes | — | Must match `flair agent add <id>` |
+| `FLAIR_AGENT_ID` | yes | — | The agent id you created — `flair init --agent <id>` or `flair agent add <id>` |
 | `FLAIR_URL` | no | `http://127.0.0.1:19926` | Reachable Flair HTTP origin |
 
 Those are the only two fields in the plugin schema (`plugin.json`). `FLAIR_KEY_PATH` and `FLAIR_ADMIN_*` are documented here in the README only — they are **not** declared as plugin variables and **not** interpolated into `mcp.json`. Set them in the host env of the machine that runs `npx`. Keeping them out of `mcp.json` is deliberate: an unsubstituted `${FLAIR_KEY_PATH}` would be truthy and break key auto-resolve, and an unsubstituted admin password would send literal Basic auth.
@@ -54,7 +54,7 @@ Cursor ships a native **Memories** feature: persistent notes the agent saves as 
 
 - Set `FLAIR_URL` to an origin the agent VM can reach. The default `http://127.0.0.1:19926` points at the npx host, which on a cloud agent is the cloud VM.
 - The agent key lives on the **npx host** at `~/.flair/keys/<id>.key` (or `FLAIR_KEY_PATH` in that machine's environment). If you cannot mount a key, set `FLAIR_ADMIN_USER` / `FLAIR_ADMIN_PASSWORD` in the host env of the machine that runs `npx` — not in plugin Configure.
-- Node **>= 22** must be on that same machine.
+- Node **>= 22.18** must be on that same machine.
 
 ## Skills
 


### PR DESCRIPTION
## The defect

The Install section led with:

> **Marketplace.** In Cursor, search **Flair** in the Marketplace, install, then **Plugins → Configure**.

**Flair is not in Cursor's Marketplace** — the listing application was declined. So the documented first step cannot succeed. A reader arriving from the plugin directory follows it, finds nothing, and reasonably concludes the plugin is abandoned or the docs are stale.

This is not a tone or emphasis question. It is an instruction that fails for every reader who tries it, on the one distribution channel we actually have.

## What changed

**Install now leads with the two paths that work** — the plugin directory listing, and copy/symlink from this repository — plus an explicit note that searching the Marketplace will not find it, so the next person doesn't re-add the old instruction in good faith.

**I deliberately did not invent a directory install command.** I could not read the rendered directory page to confirm the exact mechanism (it is behind a bot challenge), and replacing a false instruction with a guessed one is not an improvement. The listing is linked; the repository path is exact and verifiable.

Two further changes, from reading the page as a first-time visitor:

- **The H1 was `@tpsdev-ai/cursor-flair`.** A scoped npm coordinate does not tell anyone what the thing does. It now leads with the product and one concrete outcome.
- **"Flair vs Cursor's built-in Memories" sat above Prerequisites and Install** — the page compared itself to a competitor before saying what it was. Good section, wrong position; moved below Configure.

**No content was removed.** The comparison, prerequisites, cloud-agent notes, skills table and troubleshooting are unchanged.

## Not in scope, and please don't "fix" it

The public `mcp.json` leaves `@tpsdev-ai/flair-mcp` **unpinned on purpose** (#1307 added it with a CI drift check; #1308 documents the public plugin as the intended exception to the pinning posture). Public users tracking latest is the design.

## Reviewers

Kern, Sherlock — this is docs-only, so the useful question is not correctness of code but **whether any instruction here can still fail for a reader who follows it literally**. That is the class of defect being fixed, and I would rather you check for another instance of it than approve the diff.

One judgement call worth a second opinion: the new opening claims memory *"stored in a Flair instance you run, not a vendor's cloud."* That is true of the default local setup and of Fabric self-hosting. Tell me if it overstates for any supported configuration.

Refs #1421
