### PR TITLE
fix(doctor): detect MCP clients from config path, not only PATH

### DIFF
--- a/.changelog/unreleased/fixed-1417-doctor-detect-config-path.md
+++ b/.changelog/unreleased/fixed-1417-doctor-detect-config-path.md
@@ -1,0 +1,7 @@
+- **`flair doctor` detects MCP clients from their config file, not just the CLI binary** (flair#1417).
+  Cursor is a GUI app whose `cursor` shell command is opt-in; a working
+  install with `~/.cursor/mcp.json` and no `cursor` on `PATH` was reported
+  as absent, so `doctor --fix` skipped it. Detection now treats a known
+  config path as presence for every `kind: mcp` client that already has
+  one (Claude Code, Codex, Gemini, Cursor, Antigravity). Per-client
+  `detect` stays the exception.

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -5,7 +5,9 @@
 // @tpsdev-ai/flair-mcp); pi is a native-extension host (kind:
 // "native-extension" — wired via pi's own settings.json `packages` key,
 // flair#1342). Each client has:
-//   - detection: `bin` on PATH, optionally widened by a declared detect() override
+//   - detection: `bin` on PATH OR the client's known config path exists
+//     (flair#1417 — GUI-only Cursor, PATH-quirky installs). A declared
+//     detect() override remains the exception (pi).
 //   - wire(env): { ok: boolean; message: string }
 //
 // Wiring contract (FIX 4 — onboarding dogfood round 1):
@@ -52,11 +54,12 @@ export interface Client {
   kind: "mcp" | "native-extension";
   detected: boolean;
   /**
-   * Optional detection override. Default detection is `bin` on PATH (one rule,
-   * see detectClients); a client whose presence is ALSO evidenced by a config
-   * file (pi: ~/.pi/agent/settings.json survives PATH quirks like a version
-   * manager or launchd context) declares that here. Must stay a pure
-   * filesystem check — detection never spawns a subprocess (flair#946).
+   * Optional detection override. Default detection is `bin` on PATH OR the
+   * client's known config path (one rule, see detectClients — flair#1417).
+   * A client whose presence signal is not that pair (pi already used this
+   * shape before it became the default) declares the exception here. Must
+   * stay a pure filesystem check — detection never spawns a subprocess
+   * (flair#946).
    */
   detect?: () => boolean;
   wire: (env: WireEnv) => { ok: boolean; message: string };
@@ -129,12 +132,13 @@ function binInPath(name: string): boolean {
  *      elsewhere — the same defect already fixed for `flair upgrade`'s presence
  *      probes (see "Upgrade presence probes" in src/cli.ts).
  *
- * Nothing is lost by dropping it: an `npm install -g` links the package's bin
- * into the prefix's bin directory, which is on PATH by construction (it is where
- * `npm` itself is found from). A client whose binary is NOT on PATH is a client
- * the user cannot launch, and wiring an MCP config for it is at best a no-op.
- * `flair init --client <name>` still wires a client explicitly, bypassing
- * detection entirely, so an exotic install is never locked out.
+ * Nothing is lost by dropping the npm-list fallback: an `npm install -g` links
+ * the package's bin into the prefix's bin directory, which is on PATH by
+ * construction. Detection still asks PATH first. A second signal is the
+ * client's known config path (detectClients, flair#1417): a GUI install whose
+ * shell command is opt-in (Cursor) is still present when its config file
+ * exists. `flair init --client <name>` still wires a client explicitly,
+ * bypassing detection entirely, so an exotic install is never locked out.
  */
 function detectBin(bin: string): boolean {
   try {
@@ -638,10 +642,12 @@ function antigravityConfigPath(): string {
 }
 
 /**
- * Single dispatcher for "where does this client's MCP config live" — used by
+ * Single dispatcher for "where does this client's config live" — used by
  * `flair doctor`'s client-integration checks (flair#588) to read the config
- * without duplicating the per-client path logic that already lives here.
- * Additive only: does not change existing wire/detect behavior.
+ * without duplicating the per-client path logic that already lives here,
+ * and by detectClients() as the config-path presence signal (flair#1417).
+ * Every current ClientId has a path; a future id must extend this switch
+ * or stay binary-only via a `detect` override — do not invent a path.
  */
 export function clientConfigPath(id: ClientId): string {
   switch (id) {
@@ -878,17 +884,23 @@ export function renderWiringSummary(
 }
 
 /**
- * Detect every known client. One rule (`bin` on PATH) applied uniformly — a
- * client added to ALL_CLIENTS is detected by declaring its executable, with no
- * per-client branch here to forget to extend. A client may widen that with a
- * declared `detect` override (still a pure fs check — pi adds its settings
- * file as a second signal, flair#1342); the override lives on the registry
- * entry, so this function stays branch-free.
+ * Detect every known client. One rule applied uniformly: `bin` on PATH OR
+ * the client's known config path exists (flair#1417). A client added to
+ * ALL_CLIENTS is detected by declaring its executable; clientConfigPath()
+ * already names every current id, so the config-path fallback is not a
+ * per-client branch to forget. A declared `detect` override remains the
+ * exception (still a pure fs check — pi, flair#1342). Detection never
+ * spawns a subprocess (flair#946).
+ *
+ * A future client with no config path helper stays binary-only until it
+ * grows one here or a `detect` override — do not invent a path.
  */
 export function detectClients(): Client[] {
   return ALL_CLIENTS.map((client) => ({
     ...client,
-    detected: client.detect ? client.detect() : detectBin(client.bin),
+    detected: client.detect
+      ? client.detect()
+      : detectBin(client.bin) || existsSync(clientConfigPath(client.id)),
   }));
 }
 

--- a/test/unit/antigravity-client.test.ts
+++ b/test/unit/antigravity-client.test.ts
@@ -51,7 +51,8 @@ describe("Antigravity client registration (flair#1209)", () => {
     expect(antigravity).toBeDefined();
     expect(antigravity!.bin).toBe("agy");
     expect(antigravity!.label).toBe("Antigravity");
-    // detectClients() must surface it (detected flag driven by `agy` on PATH).
+    // detectClients() must surface it (detected flag driven by `agy` on PATH
+    // or ~/.gemini/config/mcp_config.json — flair#1417).
     expect(detectClients().some((c) => c.id === "antigravity")).toBe(true);
   });
 

--- a/test/unit/client-detect-config-path.test.ts
+++ b/test/unit/client-detect-config-path.test.ts
@@ -1,0 +1,103 @@
+// flair#1417 — detectClients() treats a known config path as presence, not
+// only the CLI binary on PATH.
+//
+// Cursor is the field failure: it is a GUI app whose `cursor` shell command
+// is an opt-in install step. Users with a working Cursor and ~/.cursor/mcp.json
+// but no `cursor` on PATH were reported as not-detected, and `doctor --fix`
+// skipped them.
+//
+// The same signal applies to every kind:"mcp" client that already has a
+// known config path (claude-code, codex, gemini, antigravity). Per-client
+// `detect` stays the exception (pi already uses it).
+//
+// POWERED CHECK: the Cursor config-only case MUST fail against current main,
+// where detection is binary-only and returns detected:false.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  ALL_CLIENTS,
+  clientConfigPath,
+  detectClients,
+  type ClientId,
+} from "../../src/install/clients.ts";
+
+let isoHome: string;
+let prevHome: string | undefined;
+let prevPath: string | undefined;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-detect-home-"));
+  prevHome = process.env.HOME;
+  prevPath = process.env.PATH;
+  process.env.HOME = isoHome;
+  // Equivalent of stubbing binInPath false: an isolated PATH with no client
+  // binaries. binInPath is not exported; PATH isolation is how this module's
+  // tests already turn the binary signal off (see pi-client.test.ts).
+  process.env.PATH = join(isoHome, "empty-bin");
+  mkdirSync(process.env.PATH, { recursive: true });
+});
+
+afterEach(() => {
+  if (prevHome !== undefined) process.env.HOME = prevHome;
+  else delete process.env.HOME;
+  if (prevPath !== undefined) process.env.PATH = prevPath;
+  else delete process.env.PATH;
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+function detected(id: ClientId): boolean {
+  return detectClients().find((c) => c.id === id)!.detected;
+}
+
+function writeConfig(id: ClientId, body = "{}\n"): string {
+  const path = clientConfigPath(id);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body);
+  return path;
+}
+
+describe("Cursor detection via ~/.cursor/mcp.json (flair#1417)", () => {
+  it("POWERED: detected when binInPath is false and ~/.cursor/mcp.json exists", () => {
+    writeConfig("cursor", JSON.stringify({ mcpServers: {} }, null, 2));
+    expect(detected("cursor")).toBe(true);
+  });
+
+  it("NEGATIVE: not detected when neither the binary nor ~/.cursor/mcp.json is present", () => {
+    expect(detected("cursor")).toBe(false);
+  });
+});
+
+describe("config-path fallback is general for kind:mcp clients (flair#1417)", () => {
+  const mcpIds = ALL_CLIENTS.filter((c) => c.kind === "mcp").map((c) => c.id);
+
+  it("every MCP client has a known config path — none stay binary-only for lack of a helper", () => {
+    for (const id of mcpIds) {
+      expect(clientConfigPath(id).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("detects each MCP client from its config file alone when the binary is absent", () => {
+    for (const id of mcpIds) {
+      writeConfig(id);
+      expect(`${id}=${detected(id)}`).toBe(`${id}=true`);
+      rmSync(clientConfigPath(id));
+    }
+  });
+
+  it("a sibling's config does not detect Cursor", () => {
+    writeConfig("gemini");
+    writeConfig("antigravity");
+    expect(detected("cursor")).toBe(false);
+    expect(detected("gemini")).toBe(true);
+    expect(detected("antigravity")).toBe(true);
+  });
+
+  it("NEGATIVE: no MCP client is detected when PATH and every config path are empty", () => {
+    for (const id of mcpIds) {
+      expect(`${id}=${detected(id)}`).toBe(`${id}=false`);
+    }
+  });
+});

--- a/test/unit/init-wiring-summary.test.ts
+++ b/test/unit/init-wiring-summary.test.ts
@@ -133,7 +133,7 @@ describe("renderWiringSummary — a client that was NOT wired stays visible", ()
   });
 });
 
-describe("Claude Code detection is by binary on PATH, not by its config (flair#906)", () => {
+describe("Claude Code detection fires from the binary alone (flair#906); config is a second signal (flair#1417)", () => {
   /** Put an executable named `name` in `dir` and make `dir` the entire PATH. */
   function fakeBinOnPath(dir: string, name: string) {
     const p = join(dir, name);
@@ -151,22 +151,24 @@ describe("Claude Code detection is by binary on PATH, not by its config (flair#9
     expect(claudeCode.detected).toBe(true);
   });
 
-  it("does not detect Claude Code when the binary is absent", () => {
-    // Empty PATH: no `claude` anywhere, so this exercises the negative case
-    // end to end.
+  it("does not detect Claude Code when the binary and ~/.claude.json are both absent", () => {
+    // Empty PATH: no `claude` anywhere, isolated HOME: no config file.
+    // The config-path signal (flair#1417) is a second presence check, not
+    // a default-true; this is the negative case end to end.
     process.env.PATH = isoHome;
     const claudeCode = detectClients().find(c => c.id === "claude-code")!;
     expect(claudeCode.detected).toBe(false);
   });
 
-  it("reports NO client detected when PATH holds none of their binaries", () => {
+  it("reports NO client detected when PATH holds none of their binaries and no config exists", () => {
     // The Gemini false positive: detection used to fall back to
     // `npm list -g @google/generative-ai`, which exits 0 when that package is
     // anywhere in the global tree — including as a transitive dependency of an
     // unrelated global tool. Gemini was then reported installed, and
     // ~/.gemini/settings.json written, on a machine with no `gemini` binary.
-    // PATH is the only question detection asks now, so the answer cannot
-    // depend on what else happens to be installed globally.
+    // Detection asks PATH or a known config file (flair#1417) — never a
+    // global-tree walk — so the answer cannot depend on what else happens
+    // to be installed globally. Isolated HOME means no config files either.
     process.env.PATH = isoHome;
     for (const client of detectClients()) {
       expect(`${client.id}=${client.detected}`).toBe(`${client.id}=false`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1417.

**Assign failed** — the dispatcher has no GitHub token (403). Left unassigned; Nathan will self-assign.

## The defect

Cursor is fully wired (`wireCursor`, `~/.cursor/mcp.json`, `--client cursor`) but `detectClients()` keyed solely on `detectBin("cursor")`. Cursor is a GUI app whose shell command is an opt-in install step. A working Cursor with `~/.cursor/mcp.json` and no `cursor` on `PATH` was reported as absent, and `doctor --fix` skipped it. `flair init --client cursor` still worked because an explicit `--client` is not detection-gated — the fallback required the knowledge detection was supposed to supply.

## Decision (made, not left open)

Config-path fallback is **general** for every `kind: mcp` client that already has a known config path, not a Cursor-only `detect` override. `detectClients()` is now:

```ts
detected: client.detect
  ? client.detect()
  : detectBin(client.bin) || existsSync(clientConfigPath(client.id)),
```

`clientConfigPath()` already names every current id (claude-code, codex, gemini, cursor, antigravity, pi). A future client with no path helper stays binary-only until it grows one or a `detect` override — do not invent a path. Per-client `detect` stays the exception (pi already used this shape).

That is the shape the issue asked for: decide once so Antigravity does not need the same report next month.

## What this PR does

- Default detection is `bin` on PATH **or** the client's known config path.
- Pi's `detect` override is unchanged.
- Changelog fragment (user-visible: `doctor` / `doctor --fix` now see GUI-only Cursor).

## What this PR does not do

- #1358, #1416, #1420, #1409, #1413, #998, leftovers — not in this PR.

## Powered check

`test/unit/client-detect-config-path.test.ts`. Binary signal off via isolated PATH (`binInPath` is not exported; PATH isolation is how this module already turns that signal off). `binInPath` is not stubbed via `mock.module` — bun's process-global mocks would leak, and a same-module spy would not patch the internal call.

| Case | On unmodified main (`b56df02` `clients.ts`) | This PR (`55ce994`) |
|---|---|---|
| `binInPath` false + `~/.cursor/mcp.json` exists | **RED** — `detected: false` | pass |
| Neither binary nor config present | pass (not detected) | pass |
| Each MCP client via config file alone | **RED** — binary-only | pass |
| Sibling config does not detect Cursor | **RED** on the gemini/antigravity positives | pass |

Negative control is required so "detects via config" cannot be confused with "always detects."

## Verify

Local on `55ce994e66b20d4f13318e26fa92ce7fffcadfac`:

- `bun test test/unit/client-detect-config-path.test.ts test/unit/init-wiring-summary.test.ts test/unit/pi-client.test.ts test/unit/antigravity-client.test.ts test/unit/changelog-fragments.test.ts` — **104 pass, 0 fail**.
- `node scripts/changelog-fragments.mjs check` — clean (1 fragment, 1 entry).
- Powered check re-run against `origin/main`'s `src/install/clients.ts` with this branch's tests — **3 fail / 3 pass** (config-only positives fail; both negatives still pass).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f54c62d6-c34c-4cc3-8f52-87495cf457df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f54c62d6-c34c-4cc3-8f52-87495cf457df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

