### PR TITLE
Delete unused idsInHandoffContext (follow-up to #1426)

### DIFF
--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -422,7 +422,7 @@ The four-way read:
 |---|---|
 | `pool < N` | recall gap into the pool |
 | `pool ≈ N`, `topK < N` | ranker crowding |
-| `topK ≈ N`, `readerContext < N` | **truncation — not a ranking problem** |
+| `topK ≈ N`, `readerContext < N` | **truncation — full-context only**, not a ranking problem. Harper / retrieved arms have `readerContext === topK` by construction |
 | `topK ≈ N`, `readerContext ≈ N`, still wrong | reader / prompt |
 
 `readerContext` is the formatter-admitted id set, not a prompt-string scan.

--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -425,6 +425,18 @@ The four-way read:
 | `topK ≈ N`, `readerContext < N` | **truncation — not a ranking problem** |
 | `topK ≈ N`, `readerContext ≈ N`, still wrong | reader / prompt |
 
+`readerContext` is the formatter-admitted id set, not a prompt-string scan.
+Harper arms use `ctx.items` ids (`formatRetrieved` does not truncate, so
+`readerContext === topK` structurally). Full-context uses
+`formatFullContext.includedEventIds` — events written before the char-budget
+break. A truncated event is simply not in that set.
+
+A new arm that forgets to emit an `EvidenceCoverageRecord` silently vanishes
+from `collectEvidenceCoverage` (`if (r.evidenceCoverage)`). Every arm —
+including a genuine-zero arm like `no-context` — must write a record.
+`null` / omitted is "instrument produced nothing"; a zeroed record is
+"found nothing." Distinguish those.
+
 Existing artifact fields and the aggregate shape are unchanged. Prior hashes
 stay interpretable: a historical artifact does not have this key, so
 projection drops it. The instrument is reader-free — no extra model calls.

--- a/test/bench/longmemeval/evidence-coverage.ts
+++ b/test/bench/longmemeval/evidence-coverage.ts
@@ -10,8 +10,10 @@
  *   3. evidenceEventsInReaderContext  — the prompt actually handed to the reader
  *
  * Truncation is a fourth outcome (topK ≈ N, readerContext < N), not crowding
- * (pool ≈ N, topK < N). Session-diversity selection is NOT implemented here
- * and is not imported from anywhere — this file is observation only.
+ * (pool ≈ N, topK < N). readerContext is the formatter-admitted id set
+ * (`ctx.items` / `formatFullContext.includedEventIds`), not a prompt scan.
+ * Session-diversity selection is NOT implemented here and is not imported
+ * from anywhere — this file is observation only.
  *
  * Pure. No Harper, no reader, no spend. Ground truth comes from the dataset
  * (`has_answer` turns via goldEvidenceFor). When those are absent, the
@@ -70,47 +72,6 @@ export interface HandoffCandidate {
 /** Reader-free token estimate: 4 chars/token. Not a model call. */
 export function estimateTokens(text: string): number {
   return Math.ceil((text ?? "").length / 4);
-}
-
-/**
- * Line-payload of one prompt line. Retrieved lines are `- content` or
- * `- [YYYY-MM-DD] content`. Full-context lines are `role: content`. A raw
- * substring match is not used — overlapping event text in an earlier line
- * must not count a later, unadmitted event (flair#1358 Bugbot).
- */
-function linePayload(line: string): string {
-  const t = line.trim();
-  const dated = t.match(/^- \[\d{4}-\d{2}-\d{2}\] (.*)$/);
-  if (dated) return dated[1]!;
-  if (t.startsWith("- ")) return t.slice(2);
-  const role = t.match(/^[^:]+: (.*)$/);
-  if (role) return role[1]!;
-  return t;
-}
-
-/**
- * Evidence events whose FULL content is a distinct admitted line in the
- * prompt. Each line is consumed at most once. A truncated event whose text
- * also appears inside an earlier line does not count.
- */
-export function idsInHandoffContext(
-  candidates: HandoffCandidate[],
-  context: string,
-): string[] {
-  if (!context) return [];
-  const payloads = context.split("\n").map(linePayload);
-  const used = new Set<number>();
-  const found: string[] = [];
-  for (const c of candidates) {
-    const text = (c.content ?? "").trim();
-    if (!text) continue;
-    const idx = payloads.findIndex((p, i) => !used.has(i) && p === text);
-    if (idx >= 0) {
-      used.add(idx);
-      found.push(c.id);
-    }
-  }
-  return found;
 }
 
 function countNamed(goldIds: string[], ids: string[]): number {
@@ -210,6 +171,9 @@ export function collectEvidenceCoverage(
   const questions: Array<EvidenceCoverageRecord & { runIndex: number }> = [];
   for (const run of runs) {
     for (const r of run.results) {
+      // Truthy filter: a present record (including genuine zeros) is kept;
+      // null / omitted is skipped. A new arm that forgets to emit a record
+      // silently vanishes — every arm must write one.
       if (r.evidenceCoverage) questions.push({ ...r.evidenceCoverage, runIndex: run.runIndex });
     }
   }

--- a/test/unit/longmemeval-evidence-coverage.test.ts
+++ b/test/unit/longmemeval-evidence-coverage.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import {
-  measureEvidenceCoverage, idsInHandoffContext, estimateTokens, collectEvidenceCoverage,
+  measureEvidenceCoverage, estimateTokens, collectEvidenceCoverage,
   EVIDENCE_COVERAGE_SCHEMA,
 } from "../bench/longmemeval/evidence-coverage";
 import { goldEvidenceFor, entryToSessions, type LmeEntry } from "../bench/longmemeval/dataset";
@@ -172,29 +172,11 @@ describe("four-outcome disambiguation (this change)", () => {
   });
 });
 
-describe("handoff measurement — truncation is read from the prompt string (this change)", () => {
-  test("idsInHandoffContext counts only events whose full content is in the prompt", () => {
-    const items = [
-      { id: GOLD[0]!, content: "user: I started yoga" },
-      { id: GOLD[1]!, content: "user: then spin" },
-      { id: GOLD[2]!, content: "user: then boxing" },
-    ];
-    const full = items.map((i) => `- ${i.content}`).join("\n");
-    expect(idsInHandoffContext(items, full).sort()).toEqual([...GOLD].sort());
-
-    // Truncation cut the last event mid-line — it must not count.
-    const truncated = `- ${items[0]!.content}\n- ${items[1]!.content}\n- user: then box`;
-    expect(idsInHandoffContext(items, truncated).sort()).toEqual([GOLD[0]!, GOLD[1]!].sort());
-  });
-
-  test("an empty handoff (no-context) contributes no ids", () => {
-    expect(idsInHandoffContext([{ id: GOLD[0]!, content: "user: I started yoga" }], "")).toEqual([]);
-  });
-
-  test("overlapping event text does not count a truncated gold event (Bugbot: substring match collapsed truncation)", () => {
+describe("handoff measurement — formatter-admitted ids, not a prompt scan (this change)", () => {
+  test("overlapping event text does not count a truncated gold event", () => {
     // B's ingested content is a prefix of A's. A is admitted; B is cut by the
-    // char budget. context.includes(B.content) is still true — that is the hole
-    // the first idsInHandoffContext (raw substring) had.
+    // char budget. context.includes(B.content) is still true — a prompt-string
+    // scan would count B. The shipped path uses formatFullContext.includedEventIds.
     const entry: LmeEntry = {
       question_id: "qOverlap",
       question_type: "multi-session",
@@ -230,7 +212,6 @@ describe("handoff measurement — truncation is read from the prompt string (thi
     expect(rec.n).toBe(2);
     expect(rec.evidenceEventsInFinalTopK).toBe(2);
     expect(rec.evidenceEventsInReaderContext).toBe(1);
-    expect(idsInHandoffContext([a, b], fc.text)).toEqual([a.id]);
   });
 });
 
@@ -356,5 +337,20 @@ describe("collectEvidenceCoverage", () => {
 
   test("omits the block entirely when no question carried coverage", () => {
     expect(collectEvidenceCoverage([{ runIndex: 1, results: [{}] }])).toBeUndefined();
+  });
+
+  test("keeps a genuine-zero record and drops a missing one (this change; missing vs zero)", () => {
+    const zero = measureEvidenceCoverage({
+      entry: mkNamedEntry(), arm: "no-context",
+      stages: { pool: { bm25: [], hnsw: [], fused: [] }, topK: [], readerContext: [] },
+    });
+    expect(zero.n).toBeGreaterThan(0);
+    expect(zero.evidenceEventsInFinalTopK).toBe(0);
+    const collected = collectEvidenceCoverage([
+      { runIndex: 1, results: [{ evidenceCoverage: zero }, {}] },
+    ]);
+    expect(collected!.questions).toHaveLength(1);
+    expect(collected!.questions[0]!.arm).toBe("no-context");
+    expect(collected!.questions[0]!.evidenceEventsInReaderContext).toBe(0);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1426 / Sherlock's review finding on flair#1358.

`idsInHandoffContext` was exported and unit-tested but never called by `eval.ts`, `run.ts`, `artifact.ts`, or `metrics.ts`. It looked like the truncation-safe measurement. The shipped path uses the formatter-admitted id set (`ctx.items` / `formatFullContext.includedEventIds`), which is strictly more accurate than a prompt-string scan.

This PR deletes the decoy and its tests, and documents:

- `readerContext` is the formatter-admitted id set, not a prompt scan
- Harper arms: `formatRetrieved` does not truncate, so `readerContext === topK` structurally
- Arm-extension contract: a new arm that forgets to emit an `EvidenceCoverageRecord` silently vanishes from `collectEvidenceCoverage`. Every arm — including genuine-zero `no-context` — must write a record. `null` / omitted is "instrument produced nothing"; a zeroed record is "found nothing."

No user-visible behavior change. No changelog fragment — this is bench-internal cleanup of code that never ran.

## Verify

`bun test test/unit/longmemeval-evidence-coverage.test.ts test/unit/longmemeval-arms.test.ts test/unit-isolated/semantic-search-scoping.test.ts test/unit-isolated/retrieval-score-contract-985.test.ts` — pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e33f57a1-fda5-48dc-b28e-8d031b2805fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e33f57a1-fda5-48dc-b28e-8d031b2805fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




Refs #1426 — this is the follow-up cleanup to that PR.
Refs #1430 — the invariant this PR documents in prose is guarded there.
